### PR TITLE
fix: Fix DelayNode schema.

### DIFF
--- a/pywr_schema/src/nodes/delay_node.rs
+++ b/pywr_schema/src/nodes/delay_node.rs
@@ -1,32 +1,19 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::{ParameterValue, ParameterValueType};
+use crate::parameters::ParameterValueType;
 use std::collections::HashMap;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct DelayNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
-    pub max_flow: Option<ParameterValue>,
-    pub min_flow: Option<ParameterValue>,
-    pub cost: Option<ParameterValue>,
     pub days: Option<i64>,
     pub timesteps: Option<i64>,
-    pub initial_flow: Option<i64>,
+    pub initial_flow: Option<f64>,
 }
 
 impl DelayNode {
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_flow {
-            attributes.insert("max_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_flow {
-            attributes.insert("min_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-        attributes
+        HashMap::new()
     }
 
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {


### PR DESCRIPTION
Removed cost, min_flow and max_flow as these are not supported by Pywr. initial_flow type is a float not integer.