### PR TITLE
New parameters and derive macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -141,10 +141,19 @@ dependencies = [
 name = "pywr-schema"
 version = "0.7.0"
 dependencies = [
+ "pywr-schema-macros",
  "serde",
  "serde_json",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "pywr-schema-macros"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -221,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -256,7 +265,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -113,7 +113,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
  "version_check",
 ]
 
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -143,6 +143,7 @@ version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror",
  "time",
 ]
 
@@ -157,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -187,7 +188,7 @@ checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -219,12 +220,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
     "pywr_schema",
     "pywr_validator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "pywr-schema-macros",
     "pywr_schema",
     "pywr_validator",
 ]

--- a/pywr-schema-macros/Cargo.toml
+++ b/pywr-schema-macros/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "pywr-schema-macros"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "pywr_schema_macros"
+path = "src/lib.rs"
+proc-macro = true
+
+[dependencies]
+syn = "2.0.38"
+quote = "1.0.33"
+
+

--- a/pywr-schema-macros/src/lib.rs
+++ b/pywr-schema-macros/src/lib.rs
@@ -1,6 +1,7 @@
 use proc_macro::TokenStream;
 use quote::quote;
 
+/// A derive macro for Pywr nodes that implements `parameters` and `parameters_mut` methods.
 #[proc_macro_derive(PywrNode)]
 pub fn pywr_node_macro(input: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
@@ -8,6 +9,8 @@ pub fn pywr_node_macro(input: TokenStream) -> TokenStream {
     impl_parameter_references_derive(&input)
 }
 
+/// A derive macro for Pywr parameters that implements `parameters`, `parameters_mut`,
+/// `resource_paths` and `update_resource_paths` methods.
 #[proc_macro_derive(PywrParameter)]
 pub fn pywr_parameter_macro(input: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
@@ -32,31 +35,38 @@ fn impl_parameter_references_derive(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
 
     if let syn::Data::Struct(data) = &ast.data {
+        // Only apply this to structs
+
+        // Help struct for capturing parameter fields and whether they are optional.
         struct ParamField {
             field_name: syn::Ident,
             optional: bool,
         }
 
+        // Iterate through all fields of the struct. Try to find fields that reference
+        // parameters (e.g. `Option<ParameterValue>` or `ParameterValue`).
         let parameter_fields: Vec<ParamField> = data
             .fields
             .iter()
             .filter_map(|field| {
                 let field_ident = field.ident.as_ref()?;
-
+                // Identify optional fields
                 match type_to_ident(&field.ty) {
                     Some(PywrField::Optional(ident)) => {
+                        // If optional and a parameter identifier then add to the list
                         is_parameter_ident(&ident).then_some(ParamField {
                             field_name: field_ident.clone(),
                             optional: true,
                         })
                     }
                     Some(PywrField::Required(ident)) => {
+                        // Otherwise, if a parameter identifier then add to the list
                         is_parameter_ident(&ident).then_some(ParamField {
                             field_name: field_ident.clone(),
                             optional: false,
                         })
                     }
-                    None => None,
+                    None => None, // All other fields are ignored.
                 }
             })
             .collect();
@@ -82,7 +92,7 @@ fn impl_parameter_references_derive(ast: &syn::DeriveInput) -> TokenStream {
             })
             .collect::<Vec<_>>();
 
-        // Insert statements for non-mutable version
+        // Insert statements for mutable version
         let inserts_mut = parameter_fields
             .iter()
             .map(|param_field| {
@@ -131,12 +141,14 @@ fn impl_parameter_references_derive(ast: &syn::DeriveInput) -> TokenStream {
     }
 }
 
-/// Generates a [`TokenStream`] containing the implementation `resource_paths`.
+/// Generates a [`TokenStream`] containing the implementation `resource_paths`
+/// and `update_resource_paths` methods.
 fn impl_parameter_resource_paths_derive(ast: &syn::DeriveInput) -> TokenStream {
     // Name of the node type
     let name = &ast.ident;
 
     if let syn::Data::Struct(data) = &ast.data {
+        // Helper struct to capture PathBuf fields
         struct PathField {
             field_name: syn::Ident,
             ty: PathFieldType,
@@ -149,8 +161,10 @@ fn impl_parameter_resource_paths_derive(ast: &syn::DeriveInput) -> TokenStream {
             .filter_map(|field| {
                 let field_ident = field.ident.as_ref()?;
 
+                // Identify optional fields
                 match type_to_ident(&field.ty) {
                     Some(PywrField::Optional(ident)) => {
+                        // If optional and a path identifier then add to the list
                         ident_to_path_type(&ident).map(|field_type| PathField {
                             field_name: field_ident.clone(),
                             ty: field_type,
@@ -158,13 +172,14 @@ fn impl_parameter_resource_paths_derive(ast: &syn::DeriveInput) -> TokenStream {
                         })
                     }
                     Some(PywrField::Required(ident)) => {
+                        // If required, and a path identifier then add to the list
                         ident_to_path_type(&ident).map(|field_type| PathField {
                             field_name: field_ident.clone(),
                             ty: field_type,
                             optional: false,
                         })
                     }
-                    None => None,
+                    None => None, // All other field types are ignored
                 }
             })
             .collect();
@@ -206,6 +221,7 @@ fn impl_parameter_resource_paths_derive(ast: &syn::DeriveInput) -> TokenStream {
             })
             .collect::<Vec<_>>();
 
+        // Update statements for the `update_resource_paths` method
         let updates = path_fields
             .iter()
             .map(|param_field| {
@@ -284,22 +300,28 @@ enum PywrField {
 /// Returns the last segment of a type path as an identifier
 fn type_to_ident(ty: &syn::Type) -> Option<PywrField> {
     match ty {
+        // Match type's that are a path and not a self type.
         syn::Type::Path(type_path) if type_path.qself.is_none() => {
+            // Match on the last segment
             match type_path.path.segments.last() {
                 Some(last_segment) => {
                     let ident = &last_segment.ident;
 
                     if ident == "Option" {
+                        // The last segment is an Option, now we need to parse the argument
+                        // I.e. the bit in inside the angle brackets.
                         let first_arg = match &last_segment.arguments {
                             syn::PathArguments::AngleBracketed(params) => params.args.first(),
                             _ => None,
                         };
 
+                        // Find type arguments; ignore others
                         let arg_ty = match first_arg {
                             Some(syn::GenericArgument::Type(ty)) => Some(ty),
                             _ => None,
                         };
 
+                        // Match on path types that are no self types.
                         let arg_type_path = match arg_ty {
                             Some(ty) => match ty {
                                 syn::Type::Path(type_path) if type_path.qself.is_none() => {
@@ -310,11 +332,13 @@ fn type_to_ident(ty: &syn::Type) -> Option<PywrField> {
                             None => None,
                         };
 
+                        // Get the last segment of the path
                         let last_segment = match arg_type_path {
                             Some(type_path) => type_path.path.segments.last(),
                             None => None,
                         };
 
+                        // Finally, if there's a last segment return this as an optional `PywrField`
                         match last_segment {
                             Some(last_segment) => {
                                 let ident = &last_segment.ident;
@@ -323,6 +347,7 @@ fn type_to_ident(ty: &syn::Type) -> Option<PywrField> {
                             None => None,
                         }
                     } else {
+                        // Otherwise, assume this a simple required field
                         Some(PywrField::Required(ident.clone()))
                     }
                 }

--- a/pywr-schema-macros/src/lib.rs
+++ b/pywr-schema-macros/src/lib.rs
@@ -1,0 +1,167 @@
+use proc_macro::TokenStream;
+use quote::quote;
+
+#[proc_macro_derive(PywrNode)]
+pub fn pywr_node_macro(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    impl_pywr_node_derive(&input)
+}
+
+fn impl_pywr_node_derive(ast: &syn::DeriveInput) -> TokenStream {
+    // Name of the node type
+    let name = &ast.ident;
+
+    if let syn::Data::Struct(data) = &ast.data {
+        struct ParamField {
+            ident: syn::Ident,
+            optional: bool,
+        }
+
+        let parameter_fields: Vec<ParamField> = data
+            .fields
+            .iter()
+            .filter_map(|field| {
+                let field_ident = field.ident.as_ref()?;
+
+                match &field.ty {
+                    syn::Type::Path(type_path) if type_path.qself.is_none() => {
+                        match type_path.path.segments.last() {
+                            Some(last_segment) => {
+                                let ident = &last_segment.ident;
+                                if ident == "Option" {
+                                    let first_arg = match &last_segment.arguments {
+                                        syn::PathArguments::AngleBracketed(params) => {
+                                            params.args.first()
+                                        }
+                                        _ => None,
+                                    };
+
+                                    let arg_ty = match first_arg {
+                                        Some(syn::GenericArgument::Type(ty)) => Some(ty),
+                                        _ => None,
+                                    };
+
+                                    let arg_type_path = match arg_ty {
+                                        Some(ty) => match ty {
+                                            syn::Type::Path(type_path)
+                                                if type_path.qself.is_none() =>
+                                            {
+                                                Some(type_path)
+                                            }
+                                            _ => None,
+                                        },
+                                        None => None,
+                                    };
+
+                                    let last_segment = match arg_type_path {
+                                        Some(type_path) => type_path.path.segments.last(),
+                                        None => None,
+                                    };
+
+                                    match last_segment {
+                                        Some(last_segment) => {
+                                            let ident = &last_segment.ident;
+                                            if (ident == "ParameterValue")
+                                                | (ident == "ParameterValues")
+                                            {
+                                                Some(ParamField {
+                                                    ident: field_ident.clone(),
+                                                    optional: true,
+                                                })
+                                            } else {
+                                                None
+                                            }
+                                        }
+                                        None => None,
+                                    }
+                                } else if (ident == "ParameterValue") | (ident == "ParameterValues")
+                                {
+                                    let optional = match type_path.path.segments.first() {
+                                        Some(first_segment) => first_segment.ident == "Option",
+                                        None => false,
+                                    };
+
+                                    Some(ParamField {
+                                        ident: field_ident.clone(),
+                                        optional,
+                                    })
+                                } else {
+                                    None
+                                }
+                            }
+                            None => None,
+                        }
+                    }
+                    _ => None,
+                }
+            })
+            .collect();
+
+        // ::parameters() method
+        let inserts = parameter_fields
+            .iter()
+            .map(|param_field| {
+                let ident = &param_field.ident;
+                let key = ident.to_string();
+                if param_field.optional {
+                    quote! {
+                        if let Some(p) = &self.#ident {
+                            attributes.insert(#key, p.into());
+                        }
+                    }
+                } else {
+                    quote! {
+                        let #ident = &self.#ident;
+                        attributes.insert(#key, #ident.into());
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let inserts_mut = parameter_fields
+            .iter()
+            .map(|param_field| {
+                let ident = &param_field.ident;
+                let key = ident.to_string();
+                if param_field.optional {
+                    quote! {
+                        if let Some(p) = &mut self.#ident {
+                            attributes.insert(#key, p.into());
+                        }
+                    }
+                } else {
+                    quote! {
+                        let #ident = &mut self.#ident;
+                        attributes.insert(#key, #ident.into());
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let expanded = quote! {
+            impl #name {
+                pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
+                    let mut attributes = HashMap::new();
+                    #(
+                        #inserts
+                    )*
+                    attributes
+                }
+
+                pub fn parameters_mut(&mut self) -> HashMap<&str, ParameterValueTypeMut> {
+                    let mut attributes = HashMap::new();
+                    #(
+                        #inserts_mut
+                    )*
+                    attributes
+                }
+            }
+        };
+
+        // Hand the output tokens back to the compiler.
+        TokenStream::from(expanded)
+    } else {
+        panic!("Only structs are supported for #[derive(PywrNode)]")
+    }
+}

--- a/pywr-schema-macros/src/lib.rs
+++ b/pywr-schema-macros/src/lib.rs
@@ -5,16 +5,35 @@ use quote::quote;
 pub fn pywr_node_macro(input: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
-    impl_pywr_node_derive(&input)
+    impl_parameter_references_derive(&input)
 }
 
-fn impl_pywr_node_derive(ast: &syn::DeriveInput) -> TokenStream {
+#[proc_macro_derive(PywrParameter)]
+pub fn pywr_parameter_macro(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let mut expanded = impl_parameter_references_derive(&input);
+    expanded.extend(impl_parameter_resource_paths_derive(&input));
+
+    expanded
+}
+
+/// Generates a [`TokenStream`] containing the implementation of two methods, `parameters`
+/// and `parameters_mut`, for the given struct.
+///
+/// The `parameters` method returns a [`HashMap`] of parameter names to [`ParameterValueType`],
+/// and the `parameters_mut` method returns a [`HashMap`] of parameter names to [`ParameterValueTypeMut`].
+/// This is intended to be used for nodes and parameter structs in the Pywr schema.
+///
+/// Currently the implementation is limited to simple type definitions such as `Option<ParameterValue>` or `ParameterValue`.
+fn impl_parameter_references_derive(ast: &syn::DeriveInput) -> TokenStream {
     // Name of the node type
     let name = &ast.ident;
 
     if let syn::Data::Struct(data) = &ast.data {
         struct ParamField {
-            ident: syn::Ident,
+            field_name: syn::Ident,
             optional: bool,
         }
 
@@ -24,85 +43,29 @@ fn impl_pywr_node_derive(ast: &syn::DeriveInput) -> TokenStream {
             .filter_map(|field| {
                 let field_ident = field.ident.as_ref()?;
 
-                match &field.ty {
-                    syn::Type::Path(type_path) if type_path.qself.is_none() => {
-                        match type_path.path.segments.last() {
-                            Some(last_segment) => {
-                                let ident = &last_segment.ident;
-                                if ident == "Option" {
-                                    let first_arg = match &last_segment.arguments {
-                                        syn::PathArguments::AngleBracketed(params) => {
-                                            params.args.first()
-                                        }
-                                        _ => None,
-                                    };
-
-                                    let arg_ty = match first_arg {
-                                        Some(syn::GenericArgument::Type(ty)) => Some(ty),
-                                        _ => None,
-                                    };
-
-                                    let arg_type_path = match arg_ty {
-                                        Some(ty) => match ty {
-                                            syn::Type::Path(type_path)
-                                                if type_path.qself.is_none() =>
-                                            {
-                                                Some(type_path)
-                                            }
-                                            _ => None,
-                                        },
-                                        None => None,
-                                    };
-
-                                    let last_segment = match arg_type_path {
-                                        Some(type_path) => type_path.path.segments.last(),
-                                        None => None,
-                                    };
-
-                                    match last_segment {
-                                        Some(last_segment) => {
-                                            let ident = &last_segment.ident;
-                                            if (ident == "ParameterValue")
-                                                | (ident == "ParameterValues")
-                                            {
-                                                Some(ParamField {
-                                                    ident: field_ident.clone(),
-                                                    optional: true,
-                                                })
-                                            } else {
-                                                None
-                                            }
-                                        }
-                                        None => None,
-                                    }
-                                } else if (ident == "ParameterValue") | (ident == "ParameterValues")
-                                {
-                                    let optional = match type_path.path.segments.first() {
-                                        Some(first_segment) => first_segment.ident == "Option",
-                                        None => false,
-                                    };
-
-                                    Some(ParamField {
-                                        ident: field_ident.clone(),
-                                        optional,
-                                    })
-                                } else {
-                                    None
-                                }
-                            }
-                            None => None,
-                        }
+                match type_to_ident(&field.ty) {
+                    Some(PywrField::Optional(ident)) => {
+                        is_parameter_ident(&ident).then_some(ParamField {
+                            field_name: field_ident.clone(),
+                            optional: true,
+                        })
                     }
-                    _ => None,
+                    Some(PywrField::Required(ident)) => {
+                        is_parameter_ident(&ident).then_some(ParamField {
+                            field_name: field_ident.clone(),
+                            optional: false,
+                        })
+                    }
+                    None => None,
                 }
             })
             .collect();
 
-        // ::parameters() method
+        // Insert statements for non-mutable version
         let inserts = parameter_fields
             .iter()
             .map(|param_field| {
-                let ident = &param_field.ident;
+                let ident = &param_field.field_name;
                 let key = ident.to_string();
                 if param_field.optional {
                     quote! {
@@ -119,10 +82,11 @@ fn impl_pywr_node_derive(ast: &syn::DeriveInput) -> TokenStream {
             })
             .collect::<Vec<_>>();
 
+        // Insert statements for non-mutable version
         let inserts_mut = parameter_fields
             .iter()
             .map(|param_field| {
-                let ident = &param_field.ident;
+                let ident = &param_field.field_name;
                 let key = ident.to_string();
                 if param_field.optional {
                     quote! {
@@ -139,6 +103,7 @@ fn impl_pywr_node_derive(ast: &syn::DeriveInput) -> TokenStream {
             })
             .collect::<Vec<_>>();
 
+        // Create the two parameter methods using the insert statements
         let expanded = quote! {
             impl #name {
                 pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
@@ -162,6 +127,227 @@ fn impl_pywr_node_derive(ast: &syn::DeriveInput) -> TokenStream {
         // Hand the output tokens back to the compiler.
         TokenStream::from(expanded)
     } else {
-        panic!("Only structs are supported for #[derive(PywrNode)]")
+        panic!("Only structs are supported for #[derive(PywrNode)] or #[derive(PywrParameter)]")
+    }
+}
+
+/// Generates a [`TokenStream`] containing the implementation `resource_paths`.
+fn impl_parameter_resource_paths_derive(ast: &syn::DeriveInput) -> TokenStream {
+    // Name of the node type
+    let name = &ast.ident;
+
+    if let syn::Data::Struct(data) = &ast.data {
+        struct PathField {
+            field_name: syn::Ident,
+            ty: PathFieldType,
+            optional: bool,
+        }
+
+        let path_fields: Vec<PathField> = data
+            .fields
+            .iter()
+            .filter_map(|field| {
+                let field_ident = field.ident.as_ref()?;
+
+                match type_to_ident(&field.ty) {
+                    Some(PywrField::Optional(ident)) => {
+                        ident_to_path_type(&ident).map(|field_type| PathField {
+                            field_name: field_ident.clone(),
+                            ty: field_type,
+                            optional: true,
+                        })
+                    }
+                    Some(PywrField::Required(ident)) => {
+                        ident_to_path_type(&ident).map(|field_type| PathField {
+                            field_name: field_ident.clone(),
+                            ty: field_type,
+                            optional: false,
+                        })
+                    }
+                    None => None,
+                }
+            })
+            .collect();
+
+        // Insert statements for non-mutable version
+        let inserts = path_fields
+            .iter()
+            .map(|param_field| {
+                let ident = &param_field.field_name;
+
+                match &param_field.ty {
+                    PathFieldType::ExternalDataRef => {
+                        if param_field.optional {
+                            quote! {
+                                if let Some(external) = &self.#ident {
+                                    resource_paths.push(external.url.clone());
+                                }
+                            }
+                        } else {
+                            quote! {
+                                resource_paths.push(self.#ident.url.clone());
+                            }
+                        }
+                    }
+                    PathFieldType::PathBuf => {
+                        if param_field.optional {
+                            quote! {
+                                if let Some(p) = &self.#ident {
+                                    resource_paths.push(p.clone());
+                                }
+                            }
+                        } else {
+                            quote! {
+                                resource_paths.push(self.#ident.clone());
+                            }
+                        }
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let updates = path_fields
+            .iter()
+            .map(|param_field| {
+                let ident = &param_field.field_name;
+
+                match &param_field.ty {
+                    PathFieldType::ExternalDataRef => {
+                        if param_field.optional {
+                            quote! {
+                                if let Some(external) = &mut self.#ident {
+                                    if let Some(new_path) = new_paths.get(&external.url) {
+                                        external.url = new_path.clone();
+                                    }
+                                }
+                            }
+                        } else {
+                            quote! {
+                                if let Some(new_path) = new_paths.get(&self.#ident.url) {
+                                    self.#ident.url = new_path.clone();
+                                }
+                            }
+                        }
+                    }
+                    PathFieldType::PathBuf => {
+                        if param_field.optional {
+                            quote! {
+                                if let Some(path) = &mut self.#ident {
+                                    if let Some(new_path) = new_paths.get(path) {
+                                        *path = new_path.clone();
+                                    }
+                                }
+                            }
+                        } else {
+                            quote! {
+                                if let Some(new_path) = new_paths.get(&self.#ident) {
+                                    self.#ident = new_path.clone();
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // Create the two parameter methods using the insert statements
+        let expanded = quote! {
+            impl #name {
+                pub fn resource_paths(&self) -> Vec<PathBuf> {
+                    let mut resource_paths = Vec::new();
+                    #(
+                        #inserts
+                    )*
+                    resource_paths
+                }
+
+                pub fn update_resource_paths(&mut self, new_paths: &HashMap<PathBuf, PathBuf>) {
+                    #(
+                        #updates
+                    )*
+                }
+            }
+        };
+
+        // Hand the output tokens back to the compiler.
+        TokenStream::from(expanded)
+    } else {
+        panic!("Only structs are supported for #[derive(PywrNode)] or #[derive(PywrParameter)]")
+    }
+}
+
+enum PywrField {
+    Optional(syn::Ident),
+    Required(syn::Ident),
+}
+
+/// Returns the last segment of a type path as an identifier
+fn type_to_ident(ty: &syn::Type) -> Option<PywrField> {
+    match ty {
+        syn::Type::Path(type_path) if type_path.qself.is_none() => {
+            match type_path.path.segments.last() {
+                Some(last_segment) => {
+                    let ident = &last_segment.ident;
+
+                    if ident == "Option" {
+                        let first_arg = match &last_segment.arguments {
+                            syn::PathArguments::AngleBracketed(params) => params.args.first(),
+                            _ => None,
+                        };
+
+                        let arg_ty = match first_arg {
+                            Some(syn::GenericArgument::Type(ty)) => Some(ty),
+                            _ => None,
+                        };
+
+                        let arg_type_path = match arg_ty {
+                            Some(ty) => match ty {
+                                syn::Type::Path(type_path) if type_path.qself.is_none() => {
+                                    Some(type_path)
+                                }
+                                _ => None,
+                            },
+                            None => None,
+                        };
+
+                        let last_segment = match arg_type_path {
+                            Some(type_path) => type_path.path.segments.last(),
+                            None => None,
+                        };
+
+                        match last_segment {
+                            Some(last_segment) => {
+                                let ident = &last_segment.ident;
+                                Some(PywrField::Optional(ident.clone()))
+                            }
+                            None => None,
+                        }
+                    } else {
+                        Some(PywrField::Required(ident.clone()))
+                    }
+                }
+                None => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn is_parameter_ident(ident: &syn::Ident) -> bool {
+    (ident == "ParameterValue") || (ident == "ParameterValues")
+}
+
+enum PathFieldType {
+    ExternalDataRef,
+    PathBuf,
+}
+
+fn ident_to_path_type(ident: &syn::Ident) -> Option<PathFieldType> {
+    if ident == "ExternalDataRef" {
+        Some(PathFieldType::ExternalDataRef)
+    } else if ident == "PathBuf" {
+        Some(PathFieldType::PathBuf)
+    } else {
+        None
     }
 }

--- a/pywr_schema/Cargo.toml
+++ b/pywr_schema/Cargo.toml
@@ -13,3 +13,4 @@ path = "src/lib.rs"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3.14", features = ["serde", "serde-well-known", "serde-human-readable"] }
+thiserror = "1.0.44"

--- a/pywr_schema/Cargo.toml
+++ b/pywr_schema/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3.14", features = ["serde", "serde-well-known", "serde-human-readable"] }
 thiserror = "1.0.44"
+pywr-schema-macros = { path = "../pywr-schema-macros" }

--- a/pywr_schema/src/edge.rs
+++ b/pywr_schema/src/edge.rs
@@ -1,4 +1,5 @@
 use serde::de::{self, IgnoredAny, SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
 use std::fmt;
 
 #[derive(Clone)]
@@ -57,5 +58,28 @@ impl<'de> serde::Deserialize<'de> for Edge {
         }
 
         deserializer.deserialize_seq(EdgeVisitor)
+    }
+}
+
+impl serde::Serialize for Edge {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let length = if self.from_slot.is_some() | self.to_slot.is_some() {
+            4
+        } else {
+            2
+        };
+        let mut seq = serializer.serialize_seq(Some(length))?;
+        seq.serialize_element(&self.from_node)?;
+        seq.serialize_element(&self.to_node)?;
+
+        if length == 4 {
+            seq.serialize_element(&self.from_slot)?;
+            seq.serialize_element(&self.to_slot)?;
+        }
+
+        seq.end()
     }
 }

--- a/pywr_schema/src/model.rs
+++ b/pywr_schema/src/model.rs
@@ -2,11 +2,30 @@ use crate::edge::Edge;
 use crate::nodes::Node;
 use crate::parameters::{Parameter, ParameterVec};
 use crate::tables::TableVec;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
 use time::Date;
+
+#[derive(Error, Debug)]
+pub enum PywrSchemaError {
+    #[error("An invalid URL was found.")]
+    InvalidUrlFound,
+    #[error("data store disconnected")]
+    IoError(#[from] io::Error),
+    #[error("Serde error")]
+    SerdeError(#[from] serde_json::Error),
+    #[error("Resource not found on local host: {0}")]
+    LocalResourceNotFound(PathBuf),
+    #[error("Invalid Pywr format")]
+    InvalidPywrDataFormat,
+}
 
 #[derive(serde::Deserialize, Clone)]
 pub struct Metadata {
-    pub title: String,
+    pub title: Option<String>,
     pub description: Option<String>,
     pub minimum_version: Option<String>,
 }
@@ -45,6 +64,16 @@ pub struct PywrModel {
 }
 
 impl PywrModel {
+    /// Load a PywrNetwork from a file path
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, PywrSchemaError> {
+        let file = File::open(path)?;
+        let reader = io::BufReader::new(file);
+        // Read the JSON contents of the file as an instance of `User`.
+        let data = serde_json::from_reader(reader)?;
+
+        Ok(data)
+    }
+
     /// Return a [`Node`] from its name. If no node  with that name exists return [`None`].
     pub fn get_node_by_name(&self, name: &str) -> Option<&Node> {
         self.nodes.iter().find(|n| n.name() == name)
@@ -84,11 +113,42 @@ impl PywrModel {
             None => None,
         }
     }
+
+    /// Return the model's parameter resource paths
+    pub fn parameter_resource_paths(&self) -> HashSet<PathBuf> {
+        let mut resource_paths = HashSet::new();
+
+        if let Some(parameters) = &self.parameters {
+            for parameter in parameters.iter() {
+                let paths = parameter.resource_paths();
+                resource_paths.extend(paths);
+            }
+        }
+
+        resource_paths
+    }
+
+    /// Return the model's table resource paths
+    pub fn table_resource_paths(&self) -> HashSet<PathBuf> {
+        let mut resource_paths = HashSet::new();
+
+        if let Some(tables) = &self.tables {
+            for table in tables.iter() {
+                let paths = table.resource_paths();
+                resource_paths.extend(paths);
+            }
+        }
+
+        resource_paths
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::model::PywrModel;
+    use std::ffi::OsStr;
+    use std::fs::read_dir;
+    use std::path::PathBuf;
 
     #[test]
     fn test_simple1() {
@@ -133,4 +193,74 @@ mod tests {
         assert_eq!(model.nodes.len(), 3);
         assert_eq!(model.edges.len(), 2);
     }
+
+    // #[test]
+    // fn find_urls() {
+    //     let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    //     let model_path = test_dir.join("../test-data/timeseries1.json");
+    //     let network = PywrModel::from_path(&model_path).unwrap();
+    //     let resources = network.parameter_resource_paths();
+    //     let mut expected = HashSet::new();
+    //     expected.insert(test_dir.join("../test-data/timeseries1.csv"));
+    //     assert_eq!(resources, expected);
+    // }
+
+    /// Test the models from the Pywr repository
+    #[test]
+    fn test_pywr_models() {
+        let test_models_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("models");
+        // Some models have custom parameters that cannot be deserialised
+        let exclude_models: [&OsStr; 2] = [
+            OsStr::new("extra2.json"),
+            OsStr::new("reservoir_evaporation_areafromfile.json"),
+        ];
+
+        for path in read_dir(&test_models_dir).unwrap() {
+            let model_fn = path.unwrap().path();
+            if exclude_models.contains(&model_fn.file_name().unwrap()) {
+                continue;
+            }
+            // Ensure the model can be deserialised
+            let model = PywrModel::from_path(&model_fn).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to deserialise model ({:?}) with error: {:?}",
+                    model_fn, e
+                )
+            });
+
+            // None of the standard models should have custom parameters
+            if let Some(parameters) = &model.parameters {
+                if parameters.iter().any(|p| p.is_custom()) {
+                    panic!(
+                        "Deserialised model ({:?}) contains unexpected custom parameters!",
+                        model_fn
+                    )
+                }
+            }
+        }
+    }
+
+    // #[test]
+    // fn replace_urls() {
+    //     let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    //     let model_path = test_dir.join("../test-data/timeseries1.json");
+    //     let mut network = PywrModel::from_path(&model_path).unwrap();
+    //
+    //     let urls = HashMap::from([("timeseries1.csv".to_string(), id.clone())]);
+    //     network.replace_external_resources_urls(&urls).unwrap();
+    //     let flow_url = network
+    //         .parameters
+    //         .unwrap()
+    //         .get("flow")
+    //         .unwrap()
+    //         .get("url")
+    //         .unwrap()
+    //         .as_str()
+    //         .unwrap()
+    //         .to_string();
+    //     let expected_url = format!("{}.csv", id);
+    //     assert!(flow_url == expected_url);
+    // }
 }

--- a/pywr_schema/src/model.rs
+++ b/pywr_schema/src/model.rs
@@ -2,7 +2,7 @@ use crate::edge::Edge;
 use crate::nodes::Node;
 use crate::parameters::{Parameter, ParameterVec};
 use crate::tables::TableVec;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -23,35 +23,35 @@ pub enum PywrSchemaError {
     InvalidPywrDataFormat,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct Metadata {
     pub title: Option<String>,
     pub description: Option<String>,
     pub minimum_version: Option<String>,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 #[serde(untagged)]
 pub enum Timestep {
     Days(u64),
     Frequency(String),
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct Timestepper {
     pub start: Date,
     pub end: Date,
     pub timestep: Timestep,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct Scenario {
     pub name: String,
     pub size: usize,
     pub ensemble_names: Option<Vec<String>>,
 }
 
-#[derive(serde::Deserialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct PywrModel {
     pub metadata: Metadata,
     pub timestepper: Timestepper,
@@ -165,6 +165,25 @@ impl PywrModel {
         }
 
         resource_paths
+    }
+
+    /// Update resource paths
+    pub fn update_resource_paths(&mut self, new_paths: &HashMap<PathBuf, PathBuf>) {
+        for node in &mut self.nodes {
+            node.update_resource_paths(new_paths);
+        }
+
+        if let Some(parameters) = &mut self.parameters {
+            for parameter in parameters.iter_mut() {
+                parameter.update_resource_paths(new_paths);
+            }
+        }
+
+        if let Some(tables) = &mut self.tables {
+            for table in tables.iter_mut() {
+                table.update_resource_paths(new_paths);
+            }
+        }
     }
 }
 

--- a/pywr_schema/src/model.rs
+++ b/pywr_schema/src/model.rs
@@ -25,8 +25,11 @@ pub enum PywrSchemaError {
 
 #[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct Metadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub minimum_version: Option<String>,
 }
 
@@ -48,6 +51,7 @@ pub struct Timestepper {
 pub struct Scenario {
     pub name: String,
     pub size: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ensemble_names: Option<Vec<String>>,
 }
 
@@ -55,11 +59,15 @@ pub struct Scenario {
 pub struct PywrModel {
     pub metadata: Metadata,
     pub timestepper: Timestepper,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scenarios: Option<Vec<Scenario>>,
     pub nodes: Vec<Node>,
     pub edges: Vec<Edge>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<ParameterVec>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tables: Option<TableVec>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub recorders: Option<serde_json::Value>,
 }
 

--- a/pywr_schema/src/nodes/break_link.rs
+++ b/pywr_schema/src/nodes/break_link.rs
@@ -1,8 +1,9 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::{ParameterValue, ParameterValueType};
+use crate::parameters::{ParameterValue, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrNode;
 use std::collections::HashMap;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrNode)]
 pub struct BreakLinkNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -12,20 +13,6 @@ pub struct BreakLinkNode {
 }
 
 impl BreakLinkNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_flow {
-            attributes.insert("max_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_flow {
-            attributes.insert("min_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }

--- a/pywr_schema/src/nodes/break_link.rs
+++ b/pywr_schema/src/nodes/break_link.rs
@@ -7,8 +7,11 @@ use std::collections::HashMap;
 pub struct BreakLinkNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
 }
 

--- a/pywr_schema/src/nodes/core.rs
+++ b/pywr_schema/src/nodes/core.rs
@@ -1,8 +1,11 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::{ParameterValue, ParameterValueType, ParameterValues};
+use crate::parameters::{
+    ParameterValue, ParameterValueType, ParameterValueTypeMut, ParameterValues,
+};
+use pywr_schema_macros::PywrNode;
 use std::collections::HashMap;
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct InputNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -12,27 +15,12 @@ pub struct InputNode {
 }
 
 impl InputNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_flow {
-            attributes.insert("max_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_flow {
-            attributes.insert("min_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct LinkNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -42,27 +30,12 @@ pub struct LinkNode {
 }
 
 impl LinkNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_flow {
-            attributes.insert("max_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_flow {
-            attributes.insert("min_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct OutputNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -72,27 +45,12 @@ pub struct OutputNode {
 }
 
 impl OutputNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_flow {
-            attributes.insert("max_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_flow {
-            attributes.insert("min_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct StorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -104,27 +62,12 @@ pub struct StorageNode {
 }
 
 impl StorageNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_volume {
-            attributes.insert("max_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_volume {
-            attributes.insert("min_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct ReservoirNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -136,27 +79,12 @@ pub struct ReservoirNode {
 }
 
 impl ReservoirNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_volume {
-            attributes.insert("max_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_volume {
-            attributes.insert("min_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct CatchmentNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -165,24 +93,12 @@ pub struct CatchmentNode {
 }
 
 impl CatchmentNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.flow {
-            attributes.insert("flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct AggregatedNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -194,20 +110,6 @@ pub struct AggregatedNode {
 }
 
 impl AggregatedNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.min_flow {
-            attributes.insert("min_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.max_flow {
-            attributes.insert("max_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.factors {
-            attributes.insert("factors", p.into());
-        }
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         vec![(
             "nodes",
@@ -218,7 +120,7 @@ impl AggregatedNode {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct AggregatedStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -226,10 +128,6 @@ pub struct AggregatedStorageNode {
 }
 
 impl AggregatedStorageNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         vec![(
             "storage_nodes",

--- a/pywr_schema/src/nodes/core.rs
+++ b/pywr_schema/src/nodes/core.rs
@@ -9,8 +9,11 @@ use std::collections::HashMap;
 pub struct InputNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
 }
 
@@ -24,8 +27,11 @@ impl InputNode {
 pub struct LinkNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
 }
 
@@ -39,8 +45,11 @@ impl LinkNode {
 pub struct OutputNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
 }
 
@@ -54,10 +63,15 @@ impl OutputNode {
 pub struct StorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume_pc: Option<f64>,
 }
 
@@ -71,10 +85,15 @@ impl StorageNode {
 pub struct ReservoirNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume_pc: Option<f64>,
 }
 
@@ -88,7 +107,9 @@ impl ReservoirNode {
 pub struct CatchmentNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
 }
 
@@ -103,9 +124,13 @@ pub struct AggregatedNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub factors: Option<ParameterValues>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub flow_weights: Option<Vec<f64>>,
 }
 

--- a/pywr_schema/src/nodes/delay_node.rs
+++ b/pywr_schema/src/nodes/delay_node.rs
@@ -7,8 +7,11 @@ use std::collections::HashMap;
 pub struct DelayNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub days: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timesteps: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_flow: Option<f64>,
 }
 

--- a/pywr_schema/src/nodes/delay_node.rs
+++ b/pywr_schema/src/nodes/delay_node.rs
@@ -1,8 +1,9 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::ParameterValueType;
+use crate::parameters::{ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrNode;
 use std::collections::HashMap;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrNode)]
 pub struct DelayNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -12,10 +13,6 @@ pub struct DelayNode {
 }
 
 impl DelayNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }

--- a/pywr_schema/src/nodes/loss_link.rs
+++ b/pywr_schema/src/nodes/loss_link.rs
@@ -7,9 +7,13 @@ use std::collections::HashMap;
 pub struct LossLinkNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub loss_factor: Option<ParameterValue>,
 }
 

--- a/pywr_schema/src/nodes/loss_link.rs
+++ b/pywr_schema/src/nodes/loss_link.rs
@@ -1,8 +1,9 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::{ParameterValue, ParameterValueType};
+use crate::parameters::{ParameterValue, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrNode;
 use std::collections::HashMap;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrNode)]
 pub struct LossLinkNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -13,24 +14,6 @@ pub struct LossLinkNode {
 }
 
 impl LossLinkNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_flow {
-            attributes.insert("max_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_flow {
-            attributes.insert("min_flow", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.loss_factor {
-            attributes.insert("loss_factor", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }

--- a/pywr_schema/src/nodes/mod.rs
+++ b/pywr_schema/src/nodes/mod.rs
@@ -14,7 +14,7 @@ pub use crate::nodes::core::{
     ReservoirNode, StorageNode,
 };
 pub use crate::nodes::river_split_with_gauge::RiverSplitWithGaugeNode;
-use crate::parameters::ParameterValueType;
+use crate::parameters::{ParameterValueType, ParameterValueTypeMut};
 pub use break_link::BreakLinkNode;
 pub use delay_node::DelayNode;
 pub use loss_link::LossLinkNode;
@@ -192,6 +192,33 @@ impl CoreNode {
         }
     }
 
+    pub fn parameters_mut(&mut self) -> HashMap<&str, ParameterValueTypeMut> {
+        match self {
+            CoreNode::Input(n) => n.parameters_mut(),
+            CoreNode::Link(n) => n.parameters_mut(),
+            CoreNode::Output(n) => n.parameters_mut(),
+            CoreNode::Storage(n) => n.parameters_mut(),
+            CoreNode::Reservoir(n) => n.parameters_mut(),
+            CoreNode::Catchment(n) => n.parameters_mut(),
+            CoreNode::RiverGauge(n) => n.parameters_mut(),
+            CoreNode::LossLink(n) => n.parameters_mut(),
+            CoreNode::PiecewiseLink(n) => n.parameters_mut(),
+            CoreNode::MultiSplitLink(n) => n.parameters_mut(),
+            CoreNode::BreakLink(n) => n.parameters_mut(),
+            CoreNode::Delay(n) => n.parameters_mut(),
+            CoreNode::River(n) => n.parameters_mut(),
+            CoreNode::RiverSplit(n) => n.parameters_mut(),
+            CoreNode::RiverSplitWithGauge(n) => n.parameters_mut(),
+            CoreNode::Aggregated(n) => n.parameters_mut(),
+            CoreNode::AggregatedStorage(n) => n.parameters_mut(),
+            CoreNode::VirtualStorage(n) => n.parameters_mut(),
+            CoreNode::AnnualVirtualStorage(n) => n.parameters_mut(),
+            CoreNode::MonthlyVirtualStorage(n) => n.parameters_mut(),
+            CoreNode::SeasonalVirtualStorage(n) => n.parameters_mut(),
+            CoreNode::RollingVirtualStorage(n) => n.parameters_mut(),
+        }
+    }
+
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         match self {
             CoreNode::Input(n) => n.node_references(),
@@ -256,6 +283,13 @@ impl Node {
         }
     }
 
+    pub fn parameters_mut(&mut self) -> HashMap<&str, ParameterValueTypeMut> {
+        match self {
+            Node::Core(n) => n.parameters_mut(),
+            Node::Custom(_) => HashMap::new(),
+        }
+    }
+
     pub fn resource_paths(&self) -> Vec<PathBuf> {
         let mut resource_paths = Vec::new();
 
@@ -269,5 +303,18 @@ impl Node {
         }
 
         resource_paths
+    }
+
+    pub fn update_resource_paths(&mut self, new_paths: &HashMap<PathBuf, PathBuf>) {
+        for (_, p) in self.parameters_mut() {
+            match p {
+                ParameterValueTypeMut::Single(p) => p.update_resource_paths(new_paths),
+                ParameterValueTypeMut::List(p) => {
+                    for p in p.iter_mut() {
+                        p.update_resource_paths(new_paths);
+                    }
+                }
+            };
+        }
     }
 }

--- a/pywr_schema/src/nodes/mod.rs
+++ b/pywr_schema/src/nodes/mod.rs
@@ -24,6 +24,7 @@ pub use river_gauge::RiverGaugeNode;
 pub use river_split::RiverSplitNode;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::path::PathBuf;
 pub use virtual_storage::{
     AnnualVirtualStorageNode, MonthlyVirtualStorageNode, RollingVirtualStorageNode,
     SeasonalVirtualStorageNode, VirtualStorageNode,
@@ -253,5 +254,20 @@ impl Node {
             Node::Core(n) => n.parameters(),
             Node::Custom(_) => HashMap::new(),
         }
+    }
+
+    pub fn resource_paths(&self) -> Vec<PathBuf> {
+        let mut resource_paths = Vec::new();
+
+        for (_, p) in self.parameters() {
+            let paths = match p {
+                ParameterValueType::Single(p) => p.resource_paths(),
+                ParameterValueType::List(p) => p.iter().flat_map(|p| p.resource_paths()).collect(),
+            };
+
+            resource_paths.extend(paths);
+        }
+
+        resource_paths
     }
 }

--- a/pywr_schema/src/nodes/mod.rs
+++ b/pywr_schema/src/nodes/mod.rs
@@ -32,14 +32,18 @@ pub use virtual_storage::{
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct NodePosition {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub schematic: Option<(f32, f32)>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub geographic: Option<(f32, f32)>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct NodeMeta {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub position: Option<NodePosition>,
 }
 

--- a/pywr_schema/src/nodes/multi_split.rs
+++ b/pywr_schema/src/nodes/multi_split.rs
@@ -1,5 +1,5 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::{ParameterValueType, ParameterValues};
+use crate::parameters::{ParameterValueType, ParameterValueTypeMut, ParameterValues};
 use std::collections::HashMap;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
@@ -23,6 +23,20 @@ impl MultiSplitLinkNode {
             attributes.insert("costs", costs.into());
         }
         if let Some(factors) = &self.factors {
+            attributes.insert("factors", factors.into());
+        }
+        attributes
+    }
+
+    pub fn parameters_mut(&mut self) -> HashMap<&str, ParameterValueTypeMut> {
+        let mut attributes = HashMap::new();
+        if let Some(max_flows) = &mut self.max_flows {
+            attributes.insert("max_flows", max_flows.into());
+        }
+        if let Some(costs) = &mut self.costs {
+            attributes.insert("costs", costs.into());
+        }
+        if let Some(factors) = &mut self.factors {
             attributes.insert("factors", factors.into());
         }
         attributes

--- a/pywr_schema/src/nodes/multi_split.rs
+++ b/pywr_schema/src/nodes/multi_split.rs
@@ -6,10 +6,15 @@ use std::collections::HashMap;
 pub struct MultiSplitLinkNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_flows: Option<ParameterValues>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub costs: Option<ParameterValues>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_slots: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub slot_names: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub factors: Option<ParameterValues>,
 }
 

--- a/pywr_schema/src/nodes/piecewise_link.rs
+++ b/pywr_schema/src/nodes/piecewise_link.rs
@@ -1,8 +1,9 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::{ParameterValueType, ParameterValues};
+use crate::parameters::{ParameterValueType, ParameterValueTypeMut, ParameterValues};
+use pywr_schema_macros::PywrNode;
 use std::collections::HashMap;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrNode)]
 pub struct PiecewiseLinkNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -12,17 +13,6 @@ pub struct PiecewiseLinkNode {
 }
 
 impl PiecewiseLinkNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(max_flows) = &self.max_flows {
-            attributes.insert("max_flows", max_flows.into());
-        }
-        if let Some(costs) = &self.costs {
-            attributes.insert("costs", costs.into());
-        }
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }

--- a/pywr_schema/src/nodes/piecewise_link.rs
+++ b/pywr_schema/src/nodes/piecewise_link.rs
@@ -8,7 +8,9 @@ pub struct PiecewiseLinkNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
     pub nsteps: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_flows: Option<ParameterValues>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub costs: Option<ParameterValues>,
 }
 

--- a/pywr_schema/src/nodes/river_gauge.rs
+++ b/pywr_schema/src/nodes/river_gauge.rs
@@ -7,7 +7,9 @@ use std::collections::HashMap;
 pub struct RiverGaugeNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mrf: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mrf_cost: Option<ParameterValue>,
 }
 

--- a/pywr_schema/src/nodes/river_gauge.rs
+++ b/pywr_schema/src/nodes/river_gauge.rs
@@ -1,8 +1,9 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::{ParameterValue, ParameterValueType};
+use crate::parameters::{ParameterValue, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrNode;
 use std::collections::HashMap;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrNode)]
 pub struct RiverGaugeNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -11,18 +12,6 @@ pub struct RiverGaugeNode {
 }
 
 impl RiverGaugeNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.mrf {
-            attributes.insert("mrf", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.mrf_cost {
-            attributes.insert("mrf_cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }

--- a/pywr_schema/src/nodes/river_split.rs
+++ b/pywr_schema/src/nodes/river_split.rs
@@ -7,8 +7,11 @@ use std::collections::HashMap;
 pub struct RiverSplitNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_flows: Option<ParameterValues>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub costs: Option<ParameterValues>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub slot_names: Option<Vec<String>>,
     pub factors: ParameterValues,
 }

--- a/pywr_schema/src/nodes/river_split.rs
+++ b/pywr_schema/src/nodes/river_split.rs
@@ -1,8 +1,9 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::{ParameterValueType, ParameterValues};
+use crate::parameters::{ParameterValueType, ParameterValueTypeMut, ParameterValues};
+use pywr_schema_macros::PywrNode;
 use std::collections::HashMap;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrNode)]
 pub struct RiverSplitNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -13,20 +14,6 @@ pub struct RiverSplitNode {
 }
 
 impl RiverSplitNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(max_flows) = &self.max_flows {
-            attributes.insert("max_flows", max_flows.into());
-        }
-        if let Some(costs) = &self.costs {
-            attributes.insert("costs", costs.into());
-        }
-        let factors = &self.factors;
-        attributes.insert("factors", factors.into());
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }

--- a/pywr_schema/src/nodes/river_split_with_gauge.rs
+++ b/pywr_schema/src/nodes/river_split_with_gauge.rs
@@ -1,8 +1,11 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::{ParameterValue, ParameterValueType, ParameterValues};
+use crate::parameters::{
+    ParameterValue, ParameterValueType, ParameterValueTypeMut, ParameterValues,
+};
+use pywr_schema_macros::PywrNode;
 use std::collections::HashMap;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrNode)]
 pub struct RiverSplitWithGaugeNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -14,22 +17,6 @@ pub struct RiverSplitWithGaugeNode {
 }
 
 impl RiverSplitWithGaugeNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.mrf {
-            attributes.insert("mrf", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.mrf_cost {
-            attributes.insert("mrf_cost", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-        let factors = &self.factors;
-        attributes.insert("factors", factors.into());
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         HashMap::new()
     }

--- a/pywr_schema/src/nodes/river_split_with_gauge.rs
+++ b/pywr_schema/src/nodes/river_split_with_gauge.rs
@@ -9,8 +9,11 @@ use std::collections::HashMap;
 pub struct RiverSplitWithGaugeNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mrf: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mrf_cost: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
     pub factors: ParameterValues,
     pub slot_names: Vec<String>,

--- a/pywr_schema/src/nodes/virtual_storage.rs
+++ b/pywr_schema/src/nodes/virtual_storage.rs
@@ -1,8 +1,9 @@
 use crate::nodes::NodeMeta;
-use crate::parameters::{ParameterValue, ParameterValueType};
+use crate::parameters::{ParameterValue, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrNode;
 use std::collections::HashMap;
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct VirtualStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -16,21 +17,6 @@ pub struct VirtualStorageNode {
 }
 
 impl VirtualStorageNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_volume {
-            attributes.insert("max_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_volume {
-            attributes.insert("min_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         vec![(
             "nodes",
@@ -49,7 +35,7 @@ fn default_reset_month() -> time::Month {
     time::Month::January
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct AnnualVirtualStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -69,21 +55,6 @@ pub struct AnnualVirtualStorageNode {
 }
 
 impl AnnualVirtualStorageNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_volume {
-            attributes.insert("max_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_volume {
-            attributes.insert("min_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         vec![(
             "nodes",
@@ -102,7 +73,7 @@ fn default_initial_months() -> u8 {
     1
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct MonthlyVirtualStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -122,21 +93,6 @@ pub struct MonthlyVirtualStorageNode {
 }
 
 impl MonthlyVirtualStorageNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_volume {
-            attributes.insert("max_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_volume {
-            attributes.insert("min_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         vec![(
             "nodes",
@@ -155,7 +111,7 @@ fn default_end_month() -> time::Month {
     time::Month::December
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct SeasonalVirtualStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -179,21 +135,6 @@ pub struct SeasonalVirtualStorageNode {
 }
 
 impl SeasonalVirtualStorageNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_volume {
-            attributes.insert("max_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_volume {
-            attributes.insert("min_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         vec![(
             "nodes",
@@ -204,7 +145,7 @@ impl SeasonalVirtualStorageNode {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, PywrNode)]
 pub struct RollingVirtualStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
@@ -220,21 +161,6 @@ pub struct RollingVirtualStorageNode {
 }
 
 impl RollingVirtualStorageNode {
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.max_volume {
-            attributes.insert("max_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.min_volume {
-            attributes.insert("min_volume", ParameterValueType::Single(p));
-        }
-        if let Some(p) = &self.cost {
-            attributes.insert("cost", ParameterValueType::Single(p));
-        }
-
-        attributes
-    }
-
     pub fn node_references(&self) -> HashMap<&str, Vec<&str>> {
         vec![(
             "nodes",

--- a/pywr_schema/src/nodes/virtual_storage.rs
+++ b/pywr_schema/src/nodes/virtual_storage.rs
@@ -8,11 +8,17 @@ pub struct VirtualStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub factors: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume_pc: Option<f64>,
 }
 
@@ -40,11 +46,17 @@ pub struct AnnualVirtualStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub factors: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume_pc: Option<f64>,
     #[serde(default = "default_reset_day")]
     pub reset_day: u8,
@@ -78,11 +90,17 @@ pub struct MonthlyVirtualStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub factors: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume_pc: Option<f64>,
     #[serde(default = "default_months")]
     pub months: u8,
@@ -116,11 +134,17 @@ pub struct SeasonalVirtualStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub factors: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume_pc: Option<f64>,
     #[serde(default = "default_reset_day")]
     pub reset_day: u8,
@@ -150,13 +174,21 @@ pub struct RollingVirtualStorageNode {
     #[serde(flatten)]
     pub meta: NodeMeta,
     pub nodes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub factors: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_volume: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_volume_pc: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timesteps: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub days: Option<i64>,
 }
 

--- a/pywr_schema/src/parameters/aggregated.rs
+++ b/pywr_schema/src/parameters/aggregated.rs
@@ -1,7 +1,8 @@
-use crate::parameters::{ParameterMeta, ParameterValueType};
-use std::collections::HashMap;
-
 use super::ParameterValues;
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 // TODO complete these
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
@@ -13,7 +14,7 @@ pub enum AggFunc {
     Min,
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct AggregatedParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -24,15 +25,6 @@ pub struct AggregatedParameter {
 impl AggregatedParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
-    }
-
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-
-        let parameters = &self.parameters;
-        attributes.insert("parameters", parameters.into());
-
-        attributes
     }
 }
 
@@ -47,7 +39,7 @@ pub enum IndexAggFunc {
     All,
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct AggregatedIndexParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -58,15 +50,6 @@ pub struct AggregatedIndexParameter {
 impl AggregatedIndexParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
-    }
-
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-
-        let parameters = &self.parameters;
-        attributes.insert("parameters", parameters.into());
-
-        attributes
     }
 }
 

--- a/pywr_schema/src/parameters/asymmetric_switch.rs
+++ b/pywr_schema/src/parameters/asymmetric_switch.rs
@@ -1,7 +1,9 @@
-use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct AsymmetricSwitchIndexParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -12,11 +14,5 @@ pub struct AsymmetricSwitchIndexParameter {
 impl AsymmetricSwitchIndexParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        attributes.insert("on_index_parameter", (&self.on_index_parameter).into());
-        attributes.insert("off_index_parameter", (&self.off_index_parameter).into());
-        attributes
     }
 }

--- a/pywr_schema/src/parameters/control_curves.rs
+++ b/pywr_schema/src/parameters/control_curves.rs
@@ -8,7 +8,8 @@ pub struct ControlCurveInterpolatedParameter {
     pub control_curve: Option<ParameterValue>,
     pub control_curves: Option<ParameterValues>,
     pub storage_node: String,
-    pub values: Vec<f64>,
+    pub values: Option<Vec<f64>>,
+    pub parameters: Option<ParameterValues>,
 }
 
 impl ControlCurveInterpolatedParameter {
@@ -25,6 +26,9 @@ impl ControlCurveInterpolatedParameter {
         }
         if let Some(parameters) = &self.control_curves {
             attributes.insert("control_curves", parameters.into());
+        }
+        if let Some(parameters) = &self.parameters {
+            attributes.insert("parameters", parameters.into());
         }
         attributes
     }
@@ -97,7 +101,8 @@ pub struct ControlCurvePiecewiseInterpolatedParameter {
     pub control_curves: Option<ParameterValues>,
     pub storage_node: String,
     pub values: Option<Vec<[f64; 2]>>,
-    pub minimum: f64,
+    pub parameters: Option<ParameterValues>,
+    pub minimum: Option<f64>,
 }
 
 impl ControlCurvePiecewiseInterpolatedParameter {
@@ -116,7 +121,9 @@ impl ControlCurvePiecewiseInterpolatedParameter {
         if let Some(parameters) = &self.control_curves {
             attributes.insert("control_curves", parameters.into());
         }
-
+        if let Some(parameters) = &self.parameters {
+            attributes.insert("parameters", parameters.into());
+        }
         attributes
     }
 }

--- a/pywr_schema/src/parameters/control_curves.rs
+++ b/pywr_schema/src/parameters/control_curves.rs
@@ -1,7 +1,11 @@
-use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType, ParameterValues};
+use crate::parameters::{
+    ParameterMeta, ParameterValue, ParameterValueType, ParameterValueTypeMut, ParameterValues,
+};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct ControlCurveInterpolatedParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -18,23 +22,9 @@ impl ControlCurveInterpolatedParameter {
             .into_iter()
             .collect()
     }
-
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.control_curve {
-            attributes.insert("control_curve", p.into());
-        }
-        if let Some(parameters) = &self.control_curves {
-            attributes.insert("control_curves", parameters.into());
-        }
-        if let Some(parameters) = &self.parameters {
-            attributes.insert("parameters", parameters.into());
-        }
-        attributes
-    }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct ControlCurveIndexParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -49,18 +39,9 @@ impl ControlCurveIndexParameter {
             .into_iter()
             .collect()
     }
-
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-
-        let cc = &self.control_curves;
-        attributes.insert("control_curves", cc.into());
-
-        attributes
-    }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct ControlCurveParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -77,23 +58,9 @@ impl ControlCurveParameter {
             .into_iter()
             .collect()
     }
-
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        if let Some(p) = &self.control_curve {
-            attributes.insert("control_curve", p.into());
-        }
-        if let Some(parameters) = &self.control_curves {
-            attributes.insert("control_curves", parameters.into());
-        }
-        if let Some(parameters) = &self.parameters {
-            attributes.insert("parameters", parameters.into());
-        }
-        attributes
-    }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct ControlCurvePiecewiseInterpolatedParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -110,21 +77,6 @@ impl ControlCurvePiecewiseInterpolatedParameter {
         vec![("storage_node", self.storage_node.as_str())]
             .into_iter()
             .collect()
-    }
-
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-
-        if let Some(p) = &self.control_curve {
-            attributes.insert("control_curve", p.into());
-        }
-        if let Some(parameters) = &self.control_curves {
-            attributes.insert("control_curves", parameters.into());
-        }
-        if let Some(parameters) = &self.parameters {
-            attributes.insert("parameters", parameters.into());
-        }
-        attributes
     }
 }
 

--- a/pywr_schema/src/parameters/control_curves.rs
+++ b/pywr_schema/src/parameters/control_curves.rs
@@ -64,11 +64,16 @@ impl ControlCurveParameter {
 pub struct ControlCurvePiecewiseInterpolatedParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub control_curve: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub control_curves: Option<ParameterValues>,
     pub storage_node: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub values: Option<Vec<[f64; 2]>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<ParameterValues>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub minimum: Option<f64>,
 }
 

--- a/pywr_schema/src/parameters/core.rs
+++ b/pywr_schema/src/parameters/core.rs
@@ -1,10 +1,12 @@
 use crate::parameters::{
-    ExternalDataRef, ParameterMeta, ParameterValue, ParameterValueType, TableDataRef,
+    ExternalDataRef, ParameterMeta, ParameterValue, ParameterValueType, ParameterValueTypeMut,
+    TableDataRef,
 };
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct ConstantParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -20,29 +22,9 @@ impl ConstantParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
     }
-
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
-    }
-
-    pub fn resource_paths(&self) -> Vec<PathBuf> {
-        let mut resource_paths = Vec::new();
-        if let Some(external) = &self.external {
-            resource_paths.push(external.url.clone());
-        }
-        resource_paths
-    }
-
-    pub fn update_resource_paths(&mut self, new_paths: &HashMap<PathBuf, PathBuf>) {
-        if let Some(external) = &mut self.external {
-            if let Some(new_path) = new_paths.get(&external.url) {
-                external.url = new_path.clone();
-            }
-        }
-    }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct MaxParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -54,14 +36,9 @@ impl MaxParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
     }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        attributes.insert("parameter", (&self.parameter).into());
-        attributes
-    }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct NegativeParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -72,14 +49,9 @@ impl NegativeParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
     }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        attributes.insert("parameter", (&self.parameter).into());
-        attributes
-    }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct MinParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -91,14 +63,9 @@ impl MinParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
     }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        attributes.insert("parameter", (&self.parameter).into());
-        attributes
-    }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct DivisionParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -109,11 +76,5 @@ pub struct DivisionParameter {
 impl DivisionParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-        attributes.insert("numerator", (&self.numerator).into());
-        attributes.insert("denominator", (&self.denominator).into());
-        attributes
     }
 }

--- a/pywr_schema/src/parameters/core.rs
+++ b/pywr_schema/src/parameters/core.rs
@@ -1,4 +1,6 @@
-use crate::parameters::{ExternalDataRef, ParameterMeta, ParameterValue, ParameterValueType, TableDataRef};
+use crate::parameters::{
+    ExternalDataRef, ParameterMeta, ParameterValue, ParameterValueType, TableDataRef,
+};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -9,7 +11,7 @@ pub struct ConstantParameter {
     #[serde(alias = "values")]
     pub value: Option<f64>,
     #[serde(flatten)]
-    pub external: Option<ExternalDataRef>,    
+    pub external: Option<ExternalDataRef>,
     #[serde(flatten)]
     pub table: Option<TableDataRef>,
 }
@@ -22,13 +24,21 @@ impl ConstantParameter {
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
     }
-    
+
     pub fn resource_paths(&self) -> Vec<PathBuf> {
         let mut resource_paths = Vec::new();
         if let Some(external) = &self.external {
             resource_paths.push(external.url.clone());
         }
         resource_paths
+    }
+
+    pub fn update_resource_paths(&mut self, new_paths: &HashMap<PathBuf, PathBuf>) {
+        if let Some(external) = &mut self.external {
+            if let Some(new_path) = new_paths.get(&external.url) {
+                external.url = new_path.clone();
+            }
+        }
     }
 }
 

--- a/pywr_schema/src/parameters/core.rs
+++ b/pywr_schema/src/parameters/core.rs
@@ -10,11 +10,11 @@ use std::path::PathBuf;
 pub struct ConstantParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
-    #[serde(alias = "values")]
+    #[serde(alias = "values", skip_serializing_if = "Option::is_none")]
     pub value: Option<f64>,
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub external: Option<ExternalDataRef>,
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub table: Option<TableDataRef>,
 }
 

--- a/pywr_schema/src/parameters/core.rs
+++ b/pywr_schema/src/parameters/core.rs
@@ -1,5 +1,6 @@
-use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType, TableDataRef};
+use crate::parameters::{ExternalDataRef, ParameterMeta, ParameterValue, ParameterValueType, TableDataRef};
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct ConstantParameter {
@@ -7,6 +8,8 @@ pub struct ConstantParameter {
     pub meta: Option<ParameterMeta>,
     #[serde(alias = "values")]
     pub value: Option<f64>,
+    #[serde(flatten)]
+    pub external: Option<ExternalDataRef>,    
     #[serde(flatten)]
     pub table: Option<TableDataRef>,
 }
@@ -18,6 +21,14 @@ impl ConstantParameter {
 
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
+    }
+    
+    pub fn resource_paths(&self) -> Vec<PathBuf> {
+        let mut resource_paths = Vec::new();
+        if let Some(external) = &self.external {
+            resource_paths.push(external.url.clone());
+        }
+        resource_paths
     }
 }
 

--- a/pywr_schema/src/parameters/data_frame.rs
+++ b/pywr_schema/src/parameters/data_frame.rs
@@ -7,12 +7,19 @@ use std::path::PathBuf;
 pub struct DataFrameParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scenario: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestep_offset: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub index: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub indexes: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub table: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<PathBuf>,
     #[serde(flatten)]
     pub pandas_kwargs: HashMap<String, serde_json::Value>,

--- a/pywr_schema/src/parameters/data_frame.rs
+++ b/pywr_schema/src/parameters/data_frame.rs
@@ -3,18 +3,21 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
-pub struct TablesArrayParameter {
+pub struct DataFrameParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
-    pub node: String,
-    #[serde(rename = "where")]
-    pub wh: String,
     pub scenario: Option<String>,
-    pub checksum: Option<HashMap<String, String>>,
-    pub url: PathBuf,
+    pub timestep_offset: Option<i32>,
+    pub column: Option<String>,
+    pub index: Option<String>,
+    pub indexes: Option<String>,
+    pub table: Option<String>,
+    pub url: Option<PathBuf>,
+    #[serde(flatten)]
+    pub pandas_kwargs: HashMap<String, serde_json::Value>,
 }
 
-impl TablesArrayParameter {
+impl DataFrameParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
     }
@@ -22,6 +25,10 @@ impl TablesArrayParameter {
         HashMap::new()
     }
     pub fn resource_paths(&self) -> Vec<PathBuf> {
-        vec![self.url.clone()]
+        let mut resource_paths = Vec::new();
+        if let Some(url) = &self.url {
+            resource_paths.push(url.clone());
+        }
+        resource_paths
     }
 }

--- a/pywr_schema/src/parameters/data_frame.rs
+++ b/pywr_schema/src/parameters/data_frame.rs
@@ -1,8 +1,9 @@
-use crate::parameters::{ParameterMeta, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct DataFrameParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -20,15 +21,5 @@ pub struct DataFrameParameter {
 impl DataFrameParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
-    }
-    pub fn resource_paths(&self) -> Vec<PathBuf> {
-        let mut resource_paths = Vec::new();
-        if let Some(url) = &self.url {
-            resource_paths.push(url.clone());
-        }
-        resource_paths
     }
 }

--- a/pywr_schema/src/parameters/deficit.rs
+++ b/pywr_schema/src/parameters/deficit.rs
@@ -1,7 +1,9 @@
-use crate::parameters::{ParameterMeta, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct DeficitParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -11,8 +13,5 @@ pub struct DeficitParameter {
 impl DeficitParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         vec![("node", self.node.as_str())].into_iter().collect()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
     }
 }

--- a/pywr_schema/src/parameters/deficit.rs
+++ b/pywr_schema/src/parameters/deficit.rs
@@ -1,27 +1,18 @@
 use crate::parameters::{ParameterMeta, ParameterValueType};
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
-pub struct TablesArrayParameter {
+pub struct DeficitParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
     pub node: String,
-    #[serde(rename = "where")]
-    pub wh: String,
-    pub scenario: Option<String>,
-    pub checksum: Option<HashMap<String, String>>,
-    pub url: PathBuf,
 }
 
-impl TablesArrayParameter {
+impl DeficitParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
-        HashMap::new()
+        vec![("node", self.node.as_str())].into_iter().collect()
     }
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
-    }
-    pub fn resource_paths(&self) -> Vec<PathBuf> {
-        vec![self.url.clone()]
     }
 }

--- a/pywr_schema/src/parameters/discount_factor.rs
+++ b/pywr_schema/src/parameters/discount_factor.rs
@@ -1,27 +1,19 @@
 use crate::parameters::{ParameterMeta, ParameterValueType};
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
-pub struct TablesArrayParameter {
+pub struct DiscountFactorParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
-    pub node: String,
-    #[serde(rename = "where")]
-    pub wh: String,
-    pub scenario: Option<String>,
-    pub checksum: Option<HashMap<String, String>>,
-    pub url: PathBuf,
+    pub rate: f64,
+    pub base_year: i64,
 }
 
-impl TablesArrayParameter {
+impl DiscountFactorParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
     }
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
-    }
-    pub fn resource_paths(&self) -> Vec<PathBuf> {
-        vec![self.url.clone()]
     }
 }

--- a/pywr_schema/src/parameters/discount_factor.rs
+++ b/pywr_schema/src/parameters/discount_factor.rs
@@ -1,7 +1,9 @@
-use crate::parameters::{ParameterMeta, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct DiscountFactorParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -11,9 +13,6 @@ pub struct DiscountFactorParameter {
 
 impl DiscountFactorParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
-        HashMap::new()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
     }
 }

--- a/pywr_schema/src/parameters/flow.rs
+++ b/pywr_schema/src/parameters/flow.rs
@@ -1,27 +1,18 @@
 use crate::parameters::{ParameterMeta, ParameterValueType};
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
-pub struct TablesArrayParameter {
+pub struct FlowParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
     pub node: String,
-    #[serde(rename = "where")]
-    pub wh: String,
-    pub scenario: Option<String>,
-    pub checksum: Option<HashMap<String, String>>,
-    pub url: PathBuf,
 }
 
-impl TablesArrayParameter {
+impl FlowParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
-        HashMap::new()
+        vec![("node", self.node.as_str())].into_iter().collect()
     }
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
-    }
-    pub fn resource_paths(&self) -> Vec<PathBuf> {
-        vec![self.url.clone()]
     }
 }

--- a/pywr_schema/src/parameters/flow.rs
+++ b/pywr_schema/src/parameters/flow.rs
@@ -1,7 +1,9 @@
-use crate::parameters::{ParameterMeta, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct FlowParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -11,8 +13,5 @@ pub struct FlowParameter {
 impl FlowParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         vec![("node", self.node.as_str())].into_iter().collect()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
     }
 }

--- a/pywr_schema/src/parameters/hydropower.rs
+++ b/pywr_schema/src/parameters/hydropower.rs
@@ -1,0 +1,39 @@
+use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType};
+use std::collections::HashMap;
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct HydropowerTargetParameter {
+    #[serde(flatten)]
+    pub meta: Option<ParameterMeta>,
+    pub target: ParameterValue,
+    pub water_elevation_parameter: Option<ParameterValue>,
+    pub max_flow: Option<ParameterValue>,
+    pub min_flow: Option<ParameterValue>,
+    pub turbine_elevation: Option<f64>,
+    pub efficiency: Option<f64>,
+    pub density: Option<f64>,
+    pub min_head: Option<f64>,
+    pub flow_unit_conversion: Option<f64>,
+    pub energy_unit_conversion: Option<f64>,
+}
+
+impl HydropowerTargetParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        HashMap::new()
+    }
+    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
+        let mut attributes: HashMap<&str, ParameterValueType> = HashMap::new();
+        attributes.insert("target", (&self.target).into());
+
+        if let Some(p) = &self.water_elevation_parameter {
+            attributes.insert("water_elevation_parameter", p.into());
+        }
+        if let Some(p) = &self.max_flow {
+            attributes.insert("max_flow", p.into());
+        }
+        if let Some(p) = &self.min_flow {
+            attributes.insert("min_flow", p.into());
+        }
+        attributes
+    }
+}

--- a/pywr_schema/src/parameters/hydropower.rs
+++ b/pywr_schema/src/parameters/hydropower.rs
@@ -8,14 +8,23 @@ pub struct HydropowerTargetParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
     pub target: ParameterValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub water_elevation_parameter: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_flow: Option<ParameterValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub turbine_elevation: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub efficiency: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub density: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_head: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub flow_unit_conversion: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub energy_unit_conversion: Option<f64>,
 }
 

--- a/pywr_schema/src/parameters/hydropower.rs
+++ b/pywr_schema/src/parameters/hydropower.rs
@@ -1,7 +1,9 @@
-use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct HydropowerTargetParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -20,20 +22,5 @@ pub struct HydropowerTargetParameter {
 impl HydropowerTargetParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes: HashMap<&str, ParameterValueType> = HashMap::new();
-        attributes.insert("target", (&self.target).into());
-
-        if let Some(p) = &self.water_elevation_parameter {
-            attributes.insert("water_elevation_parameter", p.into());
-        }
-        if let Some(p) = &self.max_flow {
-            attributes.insert("max_flow", p.into());
-        }
-        if let Some(p) = &self.min_flow {
-            attributes.insert("min_flow", p.into());
-        }
-        attributes
     }
 }

--- a/pywr_schema/src/parameters/indexed_array.rs
+++ b/pywr_schema/src/parameters/indexed_array.rs
@@ -1,9 +1,10 @@
-use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType};
-use std::collections::HashMap;
-
 use super::ParameterValues;
+use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
+use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct IndexedArrayParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -15,17 +16,5 @@ pub struct IndexedArrayParameter {
 impl IndexedArrayParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
-    }
-
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-
-        let p = &self.index_parameter;
-        attributes.insert("index_parameter", p.into());
-
-        let parameters = &self.parameters;
-        attributes.insert("parameters", parameters.into());
-
-        attributes
     }
 }

--- a/pywr_schema/src/parameters/interpolated.rs
+++ b/pywr_schema/src/parameters/interpolated.rs
@@ -1,7 +1,11 @@
-use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValues};
+use crate::parameters::{
+    ParameterMeta, ParameterValueType, ParameterValueTypeMut, ParameterValues,
+};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct InterpolatedVolumeParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -15,17 +19,9 @@ impl InterpolatedVolumeParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         vec![("node", self.node.as_str())].into_iter().collect()
     }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes: HashMap<&str, ParameterValueType> = HashMap::new();
-
-        attributes.insert("volumes", (&self.volumes).into());
-        attributes.insert("values", (&self.values).into());
-
-        attributes
-    }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct InterpolatedFlowParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -38,13 +34,5 @@ pub struct InterpolatedFlowParameter {
 impl InterpolatedFlowParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         vec![("node", self.node.as_str())].into_iter().collect()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes: HashMap<&str, ParameterValueType> = HashMap::new();
-
-        attributes.insert("flows", (&self.flows).into());
-        attributes.insert("values", (&self.values).into());
-
-        attributes
     }
 }

--- a/pywr_schema/src/parameters/interpolated.rs
+++ b/pywr_schema/src/parameters/interpolated.rs
@@ -1,0 +1,40 @@
+use crate::parameters::{ParameterMeta, ParameterValues, ParameterValueType};
+use std::collections::HashMap;
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct InterpolatedVolumeParameter {
+    #[serde(flatten)]
+    pub meta: Option<ParameterMeta>,
+    pub node: String,
+    pub volumes: ParameterValues, 
+    pub values: ParameterValues,  
+    pub interp_kwargs: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl InterpolatedVolumeParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        vec![("node", self.node.as_str())].into_iter().collect()
+    }
+    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
+        HashMap::new()
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct InterpolatedFlowParameter {
+    #[serde(flatten)]
+    pub meta: Option<ParameterMeta>,
+    pub node: String,
+    pub flows: Vec<f64>, // TODO this also supports loading data from tables, etc.
+    pub values: Vec<f64>, // TODO this also supports loading data from tables, etc.
+    pub interp_kwargs: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl InterpolatedFlowParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        vec![("node", self.node.as_str())].into_iter().collect()
+    }
+    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
+        HashMap::new()
+    }
+}

--- a/pywr_schema/src/parameters/interpolated.rs
+++ b/pywr_schema/src/parameters/interpolated.rs
@@ -1,4 +1,4 @@
-use crate::parameters::{ParameterMeta, ParameterValues, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValues};
 use std::collections::HashMap;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
@@ -6,8 +6,8 @@ pub struct InterpolatedVolumeParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
     pub node: String,
-    pub volumes: ParameterValues, 
-    pub values: ParameterValues,  
+    pub volumes: ParameterValues,
+    pub values: ParameterValues,
     pub interp_kwargs: Option<HashMap<String, serde_json::Value>>,
 }
 
@@ -16,7 +16,12 @@ impl InterpolatedVolumeParameter {
         vec![("node", self.node.as_str())].into_iter().collect()
     }
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
+        let mut attributes: HashMap<&str, ParameterValueType> = HashMap::new();
+
+        attributes.insert("volumes", (&self.volumes).into());
+        attributes.insert("values", (&self.values).into());
+
+        attributes
     }
 }
 
@@ -25,8 +30,8 @@ pub struct InterpolatedFlowParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
     pub node: String,
-    pub flows: Vec<f64>, // TODO this also supports loading data from tables, etc.
-    pub values: Vec<f64>, // TODO this also supports loading data from tables, etc.
+    pub flows: ParameterValues,
+    pub values: ParameterValues,
     pub interp_kwargs: Option<HashMap<String, serde_json::Value>>,
 }
 
@@ -35,6 +40,11 @@ impl InterpolatedFlowParameter {
         vec![("node", self.node.as_str())].into_iter().collect()
     }
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
+        let mut attributes: HashMap<&str, ParameterValueType> = HashMap::new();
+
+        attributes.insert("flows", (&self.flows).into());
+        attributes.insert("values", (&self.values).into());
+
+        attributes
     }
 }

--- a/pywr_schema/src/parameters/interpolated.rs
+++ b/pywr_schema/src/parameters/interpolated.rs
@@ -12,6 +12,7 @@ pub struct InterpolatedVolumeParameter {
     pub node: String,
     pub volumes: ParameterValues,
     pub values: ParameterValues,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interp_kwargs: Option<HashMap<String, serde_json::Value>>,
 }
 
@@ -28,6 +29,7 @@ pub struct InterpolatedFlowParameter {
     pub node: String,
     pub flows: ParameterValues,
     pub values: ParameterValues,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interp_kwargs: Option<HashMap<String, serde_json::Value>>,
 }
 

--- a/pywr_schema/src/parameters/mod.rs
+++ b/pywr_schema/src/parameters/mod.rs
@@ -58,7 +58,9 @@ use std::vec::IntoIter;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct ParameterMeta {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
 }
 
@@ -793,7 +795,9 @@ impl ParameterValue {
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct ExternalDataRef {
     pub url: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<TableIndex>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub index: Option<TableIndex>,
     #[serde(flatten)]
     pub attributes: HashMap<String, Value>,
@@ -816,7 +820,9 @@ pub enum TableIndexEntry {
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct TableDataRef {
     pub table: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<TableIndex>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub index: Option<TableIndex>,
 }
 

--- a/pywr_schema/src/parameters/mod.rs
+++ b/pywr_schema/src/parameters/mod.rs
@@ -348,6 +348,40 @@ impl CoreParameter {
         }
     }
 
+    pub fn parameters_mut(&mut self) -> HashMap<&str, ParameterValueTypeMut> {
+        match self {
+            Self::Constant(p) => p.parameters_mut(),
+            Self::ControlCurveInterpolated(p) => p.parameters_mut(),
+            Self::Aggregated(p) => p.parameters_mut(),
+            Self::AggregatedIndex(p) => p.parameters_mut(),
+            Self::AsymmetricSwitchIndex(p) => p.parameters_mut(),
+            Self::ControlCurvePiecewiseInterpolated(p) => p.parameters_mut(),
+            Self::ControlCurveIndex(p) => p.parameters_mut(),
+            Self::ControlCurve(p) => p.parameters_mut(),
+            Self::DailyProfile(p) => p.parameters_mut(),
+            Self::IndexedArray(p) => p.parameters_mut(),
+            Self::MonthlyProfile(p) => p.parameters_mut(),
+            Self::UniformDrawdownProfile(p) => p.parameters_mut(),
+            Self::Min(p) => p.parameters_mut(),
+            Self::Max(p) => p.parameters_mut(),
+            Self::Division(p) => p.parameters_mut(),
+            Self::Negative(p) => p.parameters_mut(),
+            Self::Polynomial1D(p) => p.parameters_mut(),
+            Self::ParameterThreshold(p) => p.parameters_mut(),
+            Self::TablesArray(p) => p.parameters_mut(),
+            Self::DataFrame(p) => p.parameters_mut(),
+            Self::Deficit(p) => p.parameters_mut(),
+            Self::DiscountFactor(p) => p.parameters_mut(),
+            Self::InterpolatedVolume(p) => p.parameters_mut(),
+            Self::InterpolatedFlow(p) => p.parameters_mut(),
+            Self::HydropowerTarget(p) => p.parameters_mut(),
+            Self::Storage(p) => p.parameters_mut(),
+            Self::RollingMeanFlowNode(p) => p.parameters_mut(),
+            Self::ScenarioWrapper(p) => p.parameters_mut(),
+            Self::Flow(p) => p.parameters_mut(),
+        }
+    }
+
     pub fn ty(&self) -> &'static str {
         match self {
             Self::Constant(_) => "Constant",
@@ -385,35 +419,35 @@ impl CoreParameter {
     /// Return any external resource paths referenced by this parameter
     pub fn resource_paths(&self) -> Vec<PathBuf> {
         match self {
-            CoreParameter::Aggregated(_) => Vec::new(),
-            CoreParameter::AggregatedIndex(_) => Vec::new(),
-            CoreParameter::AsymmetricSwitchIndex(_) => Vec::new(),
+            CoreParameter::Aggregated(p) => p.resource_paths(),
+            CoreParameter::AggregatedIndex(p) => p.resource_paths(),
+            CoreParameter::AsymmetricSwitchIndex(p) => p.resource_paths(),
             CoreParameter::Constant(p) => p.resource_paths(),
-            CoreParameter::ControlCurvePiecewiseInterpolated(_) => Vec::new(),
-            CoreParameter::ControlCurveInterpolated(_) => Vec::new(),
-            CoreParameter::ControlCurveIndex(_) => Vec::new(),
-            CoreParameter::ControlCurve(_) => Vec::new(),
+            CoreParameter::ControlCurvePiecewiseInterpolated(p) => p.resource_paths(),
+            CoreParameter::ControlCurveInterpolated(p) => p.resource_paths(),
+            CoreParameter::ControlCurveIndex(p) => p.resource_paths(),
+            CoreParameter::ControlCurve(p) => p.resource_paths(),
             CoreParameter::DailyProfile(p) => p.resource_paths(),
-            CoreParameter::IndexedArray(_) => Vec::new(),
+            CoreParameter::IndexedArray(p) => p.resource_paths(),
             CoreParameter::MonthlyProfile(p) => p.resource_paths(),
-            CoreParameter::UniformDrawdownProfile(_) => Vec::new(),
-            CoreParameter::Max(_) => Vec::new(),
-            CoreParameter::Min(_) => Vec::new(),
-            CoreParameter::Division(_) => Vec::new(),
-            CoreParameter::Negative(_) => Vec::new(),
-            CoreParameter::Polynomial1D(_) => Vec::new(),
-            CoreParameter::ParameterThreshold(_) => Vec::new(),
+            CoreParameter::UniformDrawdownProfile(p) => p.resource_paths(),
+            CoreParameter::Max(p) => p.resource_paths(),
+            CoreParameter::Min(p) => p.resource_paths(),
+            CoreParameter::Division(p) => p.resource_paths(),
+            CoreParameter::Negative(p) => p.resource_paths(),
+            CoreParameter::Polynomial1D(p) => p.resource_paths(),
+            CoreParameter::ParameterThreshold(p) => p.resource_paths(),
             CoreParameter::TablesArray(p) => p.resource_paths(),
             CoreParameter::DataFrame(p) => p.resource_paths(),
-            CoreParameter::Deficit(_) => Vec::new(),
-            CoreParameter::DiscountFactor(_) => Vec::new(),
-            CoreParameter::InterpolatedVolume(_) => Vec::new(),
-            CoreParameter::InterpolatedFlow(_) => Vec::new(),
-            CoreParameter::HydropowerTarget(_) => Vec::new(),
-            CoreParameter::Storage(_) => Vec::new(),
-            CoreParameter::RollingMeanFlowNode(_) => Vec::new(),
-            CoreParameter::ScenarioWrapper(_) => Vec::new(),
-            CoreParameter::Flow(_) => Vec::new(),
+            CoreParameter::Deficit(p) => p.resource_paths(),
+            CoreParameter::DiscountFactor(p) => p.resource_paths(),
+            CoreParameter::InterpolatedVolume(p) => p.resource_paths(),
+            CoreParameter::InterpolatedFlow(p) => p.resource_paths(),
+            CoreParameter::HydropowerTarget(p) => p.resource_paths(),
+            CoreParameter::Storage(p) => p.resource_paths(),
+            CoreParameter::RollingMeanFlowNode(p) => p.resource_paths(),
+            CoreParameter::ScenarioWrapper(p) => p.resource_paths(),
+            CoreParameter::Flow(p) => p.resource_paths(),
         }
     }
 
@@ -437,39 +471,55 @@ impl CoreParameter {
 
     pub fn update_resource_paths(&mut self, new_paths: &HashMap<PathBuf, PathBuf>) {
         match self {
-            CoreParameter::Aggregated(_) => {}
-            CoreParameter::AggregatedIndex(_) => {}
-            CoreParameter::AsymmetricSwitchIndex(_) => {}
+            CoreParameter::Aggregated(p) => p.update_resource_paths(new_paths),
+            CoreParameter::AggregatedIndex(p) => p.update_resource_paths(new_paths),
+            CoreParameter::AsymmetricSwitchIndex(p) => p.update_resource_paths(new_paths),
             CoreParameter::Constant(p) => p.update_resource_paths(new_paths),
-            CoreParameter::ControlCurvePiecewiseInterpolated(_) => {}
-            CoreParameter::ControlCurveInterpolated(_) => {}
-            CoreParameter::ControlCurveIndex(_) => {}
-            CoreParameter::ControlCurve(_) => {}
-            CoreParameter::DailyProfile(_) => {}
-            CoreParameter::IndexedArray(_) => {}
-            CoreParameter::MonthlyProfile(_) => {}
-            CoreParameter::UniformDrawdownProfile(_) => {}
-            CoreParameter::Max(_) => {}
-            CoreParameter::Min(_) => {}
-            CoreParameter::Division(_) => {}
-            CoreParameter::Negative(_) => {}
-            CoreParameter::Polynomial1D(_) => {}
-            CoreParameter::ParameterThreshold(_) => {}
-            CoreParameter::TablesArray(_) => {}
-            CoreParameter::DataFrame(_) => {}
-            CoreParameter::Deficit(_) => {}
-            CoreParameter::DiscountFactor(_) => {}
-            CoreParameter::InterpolatedVolume(_) => {}
-            CoreParameter::InterpolatedFlow(_) => {}
-            CoreParameter::HydropowerTarget(_) => {}
-            CoreParameter::Storage(_) => {}
-            CoreParameter::RollingMeanFlowNode(_) => {}
-            CoreParameter::ScenarioWrapper(_) => {}
-            CoreParameter::Flow(_) => {}
+            CoreParameter::ControlCurvePiecewiseInterpolated(p) => {
+                p.update_resource_paths(new_paths)
+            }
+            CoreParameter::ControlCurveInterpolated(p) => p.update_resource_paths(new_paths),
+            CoreParameter::ControlCurveIndex(p) => p.update_resource_paths(new_paths),
+            CoreParameter::ControlCurve(p) => p.update_resource_paths(new_paths),
+            CoreParameter::DailyProfile(p) => p.update_resource_paths(new_paths),
+            CoreParameter::IndexedArray(p) => p.update_resource_paths(new_paths),
+            CoreParameter::MonthlyProfile(p) => p.update_resource_paths(new_paths),
+            CoreParameter::UniformDrawdownProfile(p) => p.update_resource_paths(new_paths),
+            CoreParameter::Max(p) => p.update_resource_paths(new_paths),
+            CoreParameter::Min(p) => p.update_resource_paths(new_paths),
+            CoreParameter::Division(p) => p.update_resource_paths(new_paths),
+            CoreParameter::Negative(p) => p.update_resource_paths(new_paths),
+            CoreParameter::Polynomial1D(p) => p.update_resource_paths(new_paths),
+            CoreParameter::ParameterThreshold(p) => p.update_resource_paths(new_paths),
+            CoreParameter::TablesArray(p) => p.update_resource_paths(new_paths),
+            CoreParameter::DataFrame(p) => p.update_resource_paths(new_paths),
+            CoreParameter::Deficit(p) => p.update_resource_paths(new_paths),
+            CoreParameter::DiscountFactor(p) => p.update_resource_paths(new_paths),
+            CoreParameter::InterpolatedVolume(p) => p.update_resource_paths(new_paths),
+            CoreParameter::InterpolatedFlow(p) => p.update_resource_paths(new_paths),
+            CoreParameter::HydropowerTarget(p) => p.update_resource_paths(new_paths),
+            CoreParameter::Storage(p) => p.update_resource_paths(new_paths),
+            CoreParameter::RollingMeanFlowNode(p) => p.update_resource_paths(new_paths),
+            CoreParameter::ScenarioWrapper(p) => p.update_resource_paths(new_paths),
+            CoreParameter::Flow(p) => p.update_resource_paths(new_paths),
         }
     }
 
-    pub fn update_resource_paths_recursive(&mut self, new_paths: &HashMap<PathBuf, PathBuf>) {}
+    pub fn update_resource_paths_recursive(&mut self, new_paths: &HashMap<PathBuf, PathBuf>) {
+        // This parameter's resources
+        self.update_resource_paths(new_paths);
+
+        for (_, value_type) in self.parameters_mut() {
+            match value_type {
+                ParameterValueTypeMut::Single(value) => value.update_resource_paths(new_paths),
+                ParameterValueTypeMut::List(values) => {
+                    for value in values {
+                        value.update_resource_paths(new_paths);
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]

--- a/pywr_schema/src/parameters/polynomial.rs
+++ b/pywr_schema/src/parameters/polynomial.rs
@@ -9,8 +9,11 @@ pub struct Polynomial1DParameter {
     pub meta: Option<ParameterMeta>,
     pub storage_node: String,
     pub coefficients: Vec<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub use_proportional_volume: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scale: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<f64>,
 }
 

--- a/pywr_schema/src/parameters/polynomial.rs
+++ b/pywr_schema/src/parameters/polynomial.rs
@@ -1,7 +1,9 @@
-use crate::parameters::{ParameterMeta, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct Polynomial1DParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -17,8 +19,5 @@ impl Polynomial1DParameter {
         vec![("storage_node", self.storage_node.as_str())]
             .into_iter()
             .collect()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
     }
 }

--- a/pywr_schema/src/parameters/profiles.rs
+++ b/pywr_schema/src/parameters/profiles.rs
@@ -1,8 +1,11 @@
-use crate::parameters::{ExternalDataRef, ParameterMeta, ParameterValueType, TableDataRef};
+use crate::parameters::{
+    ExternalDataRef, ParameterMeta, ParameterValueType, ParameterValueTypeMut, TableDataRef,
+};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct DailyProfileParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -17,16 +20,6 @@ impl DailyProfileParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
     }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
-    }
-    pub fn resource_paths(&self) -> Vec<PathBuf> {
-        let mut resource_paths = Vec::new();
-        if let Some(external) = &self.external {
-            resource_paths.push(external.url.clone());
-        }
-        resource_paths
-    }
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
@@ -36,7 +29,7 @@ pub enum MonthInterpDay {
     Last,
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct MonthlyProfileParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -52,19 +45,9 @@ impl MonthlyProfileParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
     }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
-    }
-    pub fn resource_paths(&self) -> Vec<PathBuf> {
-        let mut resource_paths = Vec::new();
-        if let Some(external) = &self.external {
-            resource_paths.push(external.url.clone());
-        }
-        resource_paths
-    }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct UniformDrawdownProfileParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -75,9 +58,6 @@ pub struct UniformDrawdownProfileParameter {
 
 impl UniformDrawdownProfileParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
-        HashMap::new()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
     }
 }

--- a/pywr_schema/src/parameters/profiles.rs
+++ b/pywr_schema/src/parameters/profiles.rs
@@ -9,10 +9,11 @@ use std::path::PathBuf;
 pub struct DailyProfileParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub values: Option<Vec<f64>>,
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub external: Option<ExternalDataRef>,
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub table_ref: Option<TableDataRef>,
 }
 

--- a/pywr_schema/src/parameters/profiles.rs
+++ b/pywr_schema/src/parameters/profiles.rs
@@ -1,5 +1,6 @@
 use crate::parameters::{ExternalDataRef, ParameterMeta, ParameterValueType, TableDataRef};
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct DailyProfileParameter {
@@ -18,6 +19,13 @@ impl DailyProfileParameter {
     }
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
+    }
+    pub fn resource_paths(&self) -> Vec<PathBuf> {
+        let mut resource_paths = Vec::new();
+        if let Some(external) = &self.external {
+            resource_paths.push(external.url.clone());
+        }
+        resource_paths
     }
 }
 
@@ -46,6 +54,13 @@ impl MonthlyProfileParameter {
     }
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
+    }
+    pub fn resource_paths(&self) -> Vec<PathBuf> {
+        let mut resource_paths = Vec::new();
+        if let Some(external) = &self.external {
+            resource_paths.push(external.url.clone());
+        }
+        resource_paths
     }
 }
 

--- a/pywr_schema/src/parameters/rolling_mean_flow_node.rs
+++ b/pywr_schema/src/parameters/rolling_mean_flow_node.rs
@@ -1,27 +1,21 @@
 use crate::parameters::{ParameterMeta, ParameterValueType};
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
-pub struct TablesArrayParameter {
+pub struct RollingMeanFlowNodeParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
     pub node: String,
-    #[serde(rename = "where")]
-    pub wh: String,
-    pub scenario: Option<String>,
-    pub checksum: Option<HashMap<String, String>>,
-    pub url: PathBuf,
+    pub timesteps: Option<i64>,
+    pub days: Option<i64>,
+    pub initial_flow: Option<f64>,
 }
 
-impl TablesArrayParameter {
+impl RollingMeanFlowNodeParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
-        HashMap::new()
+        vec![("node", self.node.as_str())].into_iter().collect()
     }
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
-    }
-    pub fn resource_paths(&self) -> Vec<PathBuf> {
-        vec![self.url.clone()]
     }
 }

--- a/pywr_schema/src/parameters/rolling_mean_flow_node.rs
+++ b/pywr_schema/src/parameters/rolling_mean_flow_node.rs
@@ -1,7 +1,9 @@
-use crate::parameters::{ParameterMeta, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct RollingMeanFlowNodeParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -14,8 +16,5 @@ pub struct RollingMeanFlowNodeParameter {
 impl RollingMeanFlowNodeParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         vec![("node", self.node.as_str())].into_iter().collect()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
     }
 }

--- a/pywr_schema/src/parameters/scenario_wrapper.rs
+++ b/pywr_schema/src/parameters/scenario_wrapper.rs
@@ -1,7 +1,11 @@
-use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValues};
+use crate::parameters::{
+    ParameterMeta, ParameterValueType, ParameterValueTypeMut, ParameterValues,
+};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct ScenarioWrapperParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -12,13 +16,5 @@ pub struct ScenarioWrapperParameter {
 impl ScenarioWrapperParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
-    }
-
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes: HashMap<&str, ParameterValueType> = HashMap::new();
-
-        attributes.insert("parameters", (&self.parameters).into());
-
-        attributes
     }
 }

--- a/pywr_schema/src/parameters/scenario_wrapper.rs
+++ b/pywr_schema/src/parameters/scenario_wrapper.rs
@@ -15,13 +15,9 @@ impl ScenarioWrapperParameter {
     }
 
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let attributes: HashMap<&str, ParameterValueType> = HashMap::new();
+        let mut attributes: HashMap<&str, ParameterValueType> = HashMap::new();
 
-        for (_, _) in self.parameters.iter().enumerate() {
-            // TODO this doesn't work because the temporary String; needs an API change
-            // let key = format!("parameters[{}]", i);
-            // attributes.insert(&key, p.into());
-        }
+        attributes.insert("parameters", (&self.parameters).into());
 
         attributes
     }

--- a/pywr_schema/src/parameters/scenario_wrapper.rs
+++ b/pywr_schema/src/parameters/scenario_wrapper.rs
@@ -1,0 +1,28 @@
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValues};
+use std::collections::HashMap;
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub struct ScenarioWrapperParameter {
+    #[serde(flatten)]
+    pub meta: Option<ParameterMeta>,
+    pub scenario: String,
+    pub parameters: ParameterValues,
+}
+
+impl ScenarioWrapperParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        HashMap::new()
+    }
+
+    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
+        let attributes: HashMap<&str, ParameterValueType> = HashMap::new();
+
+        for (_, _) in self.parameters.iter().enumerate() {
+            // TODO this doesn't work because the temporary String; needs an API change
+            // let key = format!("parameters[{}]", i);
+            // attributes.insert(&key, p.into());
+        }
+
+        attributes
+    }
+}

--- a/pywr_schema/src/parameters/storage.rs
+++ b/pywr_schema/src/parameters/storage.rs
@@ -1,7 +1,9 @@
-use crate::parameters::{ParameterMeta, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct StorageParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -13,8 +15,5 @@ impl StorageParameter {
         vec![("storage_node", self.storage_node.as_str())]
             .into_iter()
             .collect()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
     }
 }

--- a/pywr_schema/src/parameters/storage.rs
+++ b/pywr_schema/src/parameters/storage.rs
@@ -1,27 +1,20 @@
 use crate::parameters::{ParameterMeta, ParameterValueType};
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
-pub struct TablesArrayParameter {
+pub struct StorageParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
-    pub node: String,
-    #[serde(rename = "where")]
-    pub wh: String,
-    pub scenario: Option<String>,
-    pub checksum: Option<HashMap<String, String>>,
-    pub url: PathBuf,
+    pub storage_node: String,
 }
 
-impl TablesArrayParameter {
+impl StorageParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
-        HashMap::new()
+        vec![("storage_node", self.storage_node.as_str())]
+            .into_iter()
+            .collect()
     }
     pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
         HashMap::new()
-    }
-    pub fn resource_paths(&self) -> Vec<PathBuf> {
-        vec![self.url.clone()]
     }
 }

--- a/pywr_schema/src/parameters/tables.rs
+++ b/pywr_schema/src/parameters/tables.rs
@@ -1,8 +1,9 @@
-use crate::parameters::{ParameterMeta, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct TablesArrayParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -17,11 +18,5 @@ pub struct TablesArrayParameter {
 impl TablesArrayParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        HashMap::new()
-    }
-    pub fn resource_paths(&self) -> Vec<PathBuf> {
-        vec![self.url.clone()]
     }
 }

--- a/pywr_schema/src/parameters/thresholds.rs
+++ b/pywr_schema/src/parameters/thresholds.rs
@@ -1,5 +1,7 @@
-use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType};
+use crate::parameters::{ParameterMeta, ParameterValue, ParameterValueType, ParameterValueTypeMut};
+use pywr_schema_macros::PywrParameter;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy)]
 pub enum Predicate {
@@ -15,7 +17,7 @@ pub enum Predicate {
     GE,
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct ParameterThresholdParameter {
     #[serde(flatten)]
     pub meta: Option<ParameterMeta>,
@@ -28,14 +30,5 @@ pub struct ParameterThresholdParameter {
 impl ParameterThresholdParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
-    }
-    pub fn parameters(&self) -> HashMap<&str, ParameterValueType> {
-        let mut attributes = HashMap::new();
-
-        attributes.insert("parameter", (&self.parameter).into());
-
-        attributes.insert("threshold", (&self.threshold).into());
-
-        attributes
     }
 }

--- a/pywr_schema/src/tables.rs
+++ b/pywr_schema/src/tables.rs
@@ -6,12 +6,19 @@ use std::collections::HashMap;
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
 use std::vec::IntoIter;
 
 #[derive(serde::Deserialize, Clone)]
 pub struct Table {
     pub name: String,
-    pub url: String,
+    pub url: PathBuf,
+}
+
+impl Table {
+    pub fn resource_paths(&self) -> Vec<PathBuf> {
+        vec![self.url.clone()]
+    }
 }
 
 #[derive(Clone)]

--- a/pywr_schema/tests/models/agg_recorder_nesting.json
+++ b/pywr_schema/tests/models/agg_recorder_nesting.json
@@ -1,0 +1,83 @@
+{
+    "metadata": {
+        "title": "Parameter recorder",
+        "description": "JSON example of parameter recorder",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": "supply_max"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": "demand_max",
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"]
+    ],
+    "parameters": {
+        "demand_max": {
+            "type": "constant",
+            "value": 10
+        },
+        "supply_max": {
+            "type": "constant",
+            "value": 15,
+            "name": "supply_max"
+        }
+    },
+    "recorders": {
+        "demand_max_recorder1": {
+            "type": "NumpyArrayParameterRecorder",
+            "parameter": "demand_max"
+        },
+        "demand_max_recorder2": {
+            "type": "NumpyArrayParameterRecorder",
+            "parameter": "demand_max"
+        },
+        "supply_max_recorder1": {
+            "type": "NumpyArrayParameterRecorder",
+            "node": "supply1",
+            "parameter": "supply_max"
+        },
+        "supply_max_recorder2": {
+            "type": "NumpyArrayParameterRecorder",
+            "node": "supply1",
+            "parameter": "supply_max"
+        },
+        "demand_max_recorder": {
+            "type": "aggregated",
+            "recorder_agg_func": "mean",
+            "recorders": [
+                "demand_max_recorder1",
+                "demand_max_recorder2"
+            ]
+        },
+        "supply_max_recorder": {
+            "type": "aggregated",
+            "recorder_agg_func": "mean",
+            "recorders": [
+                "supply_max_recorder1",
+                "supply_max_recorder2"
+            ]
+        },
+        "max_recorder": {
+            "type": "aggregated",
+            "recorder_agg_func": "sum",
+            "recorders": [
+                "demand_max_recorder",
+                "supply_max_recorder"
+            ]
+        }
+    }
+}

--- a/pywr_schema/tests/models/aggregated1.json
+++ b/pywr_schema/tests/models/aggregated1.json
@@ -1,0 +1,42 @@
+{
+    "metadata": {
+        "title": "Test of aggregated node constraints",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2016-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "A",
+            "type": "input",
+            "max_flow": 50
+        },
+        {
+            "name": "B",
+            "type": "input",
+            "max_flow": 50
+        },
+        {
+            "name": "Z",
+            "type": "output",
+            "max_flow": 100,
+            "cost": -100
+        },
+        {
+            "name": "agg",
+            "type": "AggregatedNode",
+            "nodes": ["A", "B"],
+            "factors": [2.0, 4.0],
+            "flow_weights": [1.0, 1.0],
+            "max_flow": 30.0,
+            "min_flow": 5.0
+        }
+    ],
+    "edges": [
+        ["A", "Z"],
+        ["B", "Z"]
+    ]
+}

--- a/pywr_schema/tests/models/aggregated_with_two_nodes_same_route.json
+++ b/pywr_schema/tests/models/aggregated_with_two_nodes_same_route.json
@@ -1,0 +1,54 @@
+{
+    "metadata": {
+        "title": "Test of aggregated node constraints",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2016-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "A",
+            "type": "input",
+            "max_flow": 50
+        },
+        {
+            "name": "B",
+            "type": "input",
+            "max_flow": 50
+        },
+        {
+            "name": "C",
+            "type": "input",
+            "max_flow": 50
+        },
+        {
+            "name": "X",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "Z",
+            "type": "output",
+            "max_flow": 100,
+            "cost": -100
+        },
+        {
+            "name": "agg",
+            "type": "AggregatedNode",
+            "nodes": ["A", "B", "C", "X"],
+            "factors": [1.0, 1.0, 1.0, 1.0],
+            "flow_weights": [1.0, 1.0, 1.0, 1.0],
+            "max_flow": 30.0,
+            "min_flow": 5.0
+        }
+    ],
+    "edges": [
+        ["A", "X"],
+        ["X", "Z"],
+        ["B", "Z"],
+        ["C", "Z"]
+    ]
+}

--- a/pywr_schema/tests/models/annual_license.json
+++ b/pywr_schema/tests/models/annual_license.json
@@ -1,0 +1,39 @@
+{
+    "metadata": {
+        "title": "Annual license test",
+        "minimum_version": "0.5dev0"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": {
+                "type": "annuallicense",
+                "node": "supply1",
+                "amount": 200
+            }
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": {
+                "type": "arrayindexed",
+                "values": [50, 50, 0, 50, 50, 50, 50]
+            },
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/bottleneck.json
+++ b/pywr_schema/tests/models/bottleneck.json
@@ -1,0 +1,47 @@
+{
+    "metadata": {
+        "title": "Bottleneck",
+        "description": "A network with a bottleneck.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 20
+        },
+        {
+            "name": "supply2",
+            "type": "Input",
+            "max_flow": 20
+        },
+        {
+            "name": "link1",
+            "type": "Link",
+            "max_flow": 15
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "demand2",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["supply2", "link1"],
+        ["link1", "demand1"],
+        ["link1", "demand2"]
+    ]
+}

--- a/pywr_schema/tests/models/breaklink.json
+++ b/pywr_schema/tests/models/breaklink.json
@@ -1,0 +1,31 @@
+{
+    "metadata": {
+        "minimum_version": "0.4dev0"
+    },
+    "timestepper": {
+        "start": "1995-01-01",
+        "end": "1995-01-05",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "A",
+            "type": "input"
+        },
+        {
+            "name": "C",
+            "type": "output",
+            "cost": -1,
+            "max_flow": 100.0
+        },
+        {
+            "name": "B",
+            "type": "breaklink",
+            "max_flow": 20.0
+        }
+    ],
+    "edges": [
+        ["A", "B"],
+        ["B", "C"]
+    ]
+}

--- a/pywr_schema/tests/models/cost1.json
+++ b/pywr_schema/tests/models/cost1.json
@@ -1,0 +1,36 @@
+{
+    "metadata": {
+        "title": "Cost 1",
+        "description": "A very simple example of supply costs.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15,
+            "cost": 1
+        },
+        {
+            "name": "supply2",
+            "type": "Input",
+            "max_flow": 15,
+            "cost": 2
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"],
+        ["supply2", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/csv_recorder.json
+++ b/pywr_schema/tests/models/csv_recorder.json
@@ -1,0 +1,35 @@
+{
+    "metadata": {
+        "title": "json with csv recoder example",
+        "description": "A model with a csv recoder",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "inpt",
+            "type": "input",
+            "max_flow": 10.0
+        },
+        {
+            "name": "otpt",
+            "type": "Output",
+            "cost": -2
+        }
+    ],
+    "edges": [
+        ["inpt", "otpt"]
+    ],
+    "recorders": {
+        "model_out": {
+            "comment": "flow to opt node",
+            "type": "CSVRecorder",
+            "nodes": ["inpt","otpt"],
+            "url": "output.csv"
+        }
+    }
+}

--- a/pywr_schema/tests/models/dangling_link.json
+++ b/pywr_schema/tests/models/dangling_link.json
@@ -1,0 +1,38 @@
+{
+    "metadata": {
+        "title": "Dangling link",
+        "description": "An example of an a model with an unconnected link.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "link2",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["supply1", "link2"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/deficit.json
+++ b/pywr_schema/tests/models/deficit.json
@@ -1,0 +1,59 @@
+{
+    "metadata": {
+        "title": "Deficit",
+        "description": "Example of deficit parameter",
+        "minimum_version": "0.4dev0"
+    },
+    "timestepper": {
+        "start": "2015-01-20",
+        "end": "2015-12-31",
+        "timestep": 31
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": {
+                "type": "monthlyprofile",
+                "values": [5, 6, 7, 8, 9, 10, 11, 12, 11, 10, 9, 8]
+            }
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "yesterday_deficit",
+            "type": "input",
+            "max_flow": "deficit"
+        },
+        {
+            "name": "dummy_output",
+            "type": "output",
+            "max_flow": null,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"],
+        ["yesterday_deficit", "dummy_output"]
+    ],
+    "parameters": {
+        "deficit": {
+            "type": "deficit",
+            "node": "demand1"
+        }
+    },
+    "recorders": {
+        "deficit_recorder": {
+            "type": "numpyarrayparameterrecorder",
+            "parameter": "deficit"
+        },
+        "yesterday_recorder": {
+            "type": "numpyarraynoderecorder",
+            "node": "yesterday_deficit"
+        }
+    }
+}

--- a/pywr_schema/tests/models/demand_saving2.json
+++ b/pywr_schema/tests/models/demand_saving2.json
@@ -1,0 +1,98 @@
+{
+    "metadata": {
+        "title": "Demand Saving",
+        "description": "Demand saving using an IndexedArrayParameter",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2016-01-01",
+        "end": "2016-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "type": "catchment",
+            "name": "Inflow",
+            "flow": 0.0
+        },
+        {
+            "type": "reservoir",
+            "name": "Reservoir",
+            "max_volume": 1000,
+            "initial_volume": 1000
+        },
+        {
+            "type": "output",
+            "name": "Spill",
+            "cost": 10
+        },
+        {
+            "comment": "The only demand in the model",
+            "type": "output",
+            "name": "Demand",
+            "max_flow": "demand_max_flow",
+            "cost": -500
+        }
+    ],
+    "edges": [
+        ["Inflow", "Reservoir"],
+        ["Reservoir", "Demand"],
+        ["Reservoir", "Spill"]
+    ],
+    "parameters": {
+        "demand_baseline": {
+            "type": "constant",
+            "value": 50
+        },
+        "demand_profile": {
+            "comment": "Monthly demand profile as a factor around the mean demand",
+            "type": "monthlyprofile",
+            "values": [0.9, 0.9, 0.9, 0.9, 1.2, 1.2, 1.2, 1.2, 0.9, 0.9, 0.9, 0.9]
+        },
+        "level1": {
+            "type": "constant",
+            "value": 0.8
+        },
+        "level2": {
+            "type": "constant",
+            "value": 0.5
+        },
+        "demand_saving_level": {
+            "comment": "The demand saving level",
+            "type": "controlcurveindex",
+            "storage_node": "Reservoir",
+            "control_curves": [
+                "level1",
+                "level2"
+            ]
+        },
+        "demand_saving_factor": {
+            "comment": "Demand saving as a factor of the base demand",
+            "type": "indexedarray",
+            "index_parameter": "demand_saving_level",
+            "params": [
+                {
+                    "type": "constant",
+                    "value": 1.0
+                },
+                {
+                    "type": "monthlyprofile",
+                    "values": [0.95, 0.95, 0.95, 0.95, 0.90, 0.90, 0.90, 0.90, 0.95, 0.95, 0.95, 0.95]
+                },
+                {
+                    "type": "monthlyprofile",
+                    "values": [0.5, 0.5, 0.5, 0.5, 0.4, 0.4, 0.4, 0.4, 0.5, 0.5, 0.5, 0.5]
+                }
+            ]
+        },
+        "demand_max_flow": {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                "demand_baseline",
+                "demand_profile",
+                "demand_saving_factor"
+            ]
+        }
+    }
+}

--- a/pywr_schema/tests/models/demand_saving2_with_variables.json
+++ b/pywr_schema/tests/models/demand_saving2_with_variables.json
@@ -1,0 +1,117 @@
+{
+    "metadata": {
+        "title": "Demand Saving",
+        "description": "Demand saving using an IndexedArrayParameter with variables and constraints",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2016-01-01",
+        "end": "2016-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "type": "catchment",
+            "name": "Inflow",
+            "flow": 0.0
+        },
+        {
+            "type": "reservoir",
+            "name": "Reservoir",
+            "max_volume": 1000,
+            "initial_volume": 1000,
+            "position": {
+                "schematic": [1, 1]
+            }
+        },
+        {
+            "type": "output",
+            "name": "Spill",
+            "cost": 10
+        },
+        {
+            "comment": "The only demand in the model",
+            "type": "output",
+            "name": "Demand",
+            "max_flow": "demand_max_flow",
+            "cost": -500
+        }
+    ],
+    "edges": [
+        ["Inflow", "Reservoir"],
+        ["Reservoir", "Demand"],
+        ["Reservoir", "Spill"]
+    ],
+    "parameters": {
+        "demand_baseline": {
+            "type": "constant",
+            "value": 50
+        },
+        "demand_profile": {
+            "comment": "Monthly demand profile as a factor around the mean demand",
+            "type": "monthlyprofile",
+            "values": [0.9, 0.9, 0.9, 0.9, 1.2, 1.2, 1.2, 1.2, 0.9, 0.9, 0.9, 0.9],
+            "is_variable": true
+
+        },
+        "level1": {
+            "type": "constant",
+            "value": 0.8,
+            "is_variable": true
+        },
+        "level2": {
+            "type": "constant",
+            "value": 0.5,
+            "is_variable": true
+        },
+        "demand_saving_level": {
+            "comment": "The demand saving level",
+            "type": "controlcurveindex",
+            "storage_node": "Reservoir",
+            "control_curves": [
+                "level1",
+                "level2"
+            ]
+        },
+        "demand_saving_factor": {
+            "comment": "Demand saving as a factor of the base demand",
+            "type": "indexedarray",
+            "index_parameter": "demand_saving_level",
+            "params": [
+                {
+                    "type": "constant",
+                    "value": 1.0
+                },
+                {
+                    "type": "monthlyprofile",
+                    "values": [0.95, 0.95, 0.95, 0.95, 0.90, 0.90, 0.90, 0.90, 0.95, 0.95, 0.95, 0.95]
+                },
+                {
+                    "type": "monthlyprofile",
+                    "values": [0.5, 0.5, 0.5, 0.5, 0.4, 0.4, 0.4, 0.4, 0.5, 0.5, 0.5, 0.5]
+                }
+            ]
+        },
+        "demand_max_flow": {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                "demand_baseline",
+                "demand_profile",
+                "demand_saving_factor"
+            ]
+        }
+    },
+    "recorders": {
+        "total_deficit": {
+            "type": "totaldeficitnode",
+            "node": "Demand",
+            "is_objective": "minimise"
+        },
+        "min_volume": {
+            "type": "MinimumVolumeStorage",
+            "node": "Reservoir",
+            "constraint_lower_bounds": 100
+        }
+    }
+}

--- a/pywr_schema/tests/models/demand_saving_hdf.json
+++ b/pywr_schema/tests/models/demand_saving_hdf.json
@@ -1,0 +1,86 @@
+{
+    "metadata": {
+        "title": "Demand Saving",
+        "description": "Demand saving using an IndexedArrayParameter",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2016-01-01",
+        "end": "2016-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "type": "catchment",
+            "name": "Inflow",
+            "flow": 0.0
+        },
+        {
+            "type": "reservoir",
+            "name": "Reservoir",
+            "max_volume": 1000,
+            "initial_volume": 1000
+        },
+        {
+            "type": "output",
+            "name": "Spill",
+            "cost": 10
+        },
+        {
+            "comment": "The only demand in the model",
+            "type": "output",
+            "name": "Demand",
+            "max_flow": "demand_max_flow",
+            "cost": -500
+        }
+    ],
+    "edges": [
+        ["Inflow", "Reservoir"],
+        ["Reservoir", "Demand"],
+        ["Reservoir", "Spill"]
+    ],
+    "parameters": {
+        "demand_baseline": {
+            "type": "constant",
+            "value": 50
+        },
+        "demand_saving_level": {
+            "comment": "The demand saving level",
+            "type": "tablesarray",
+            "url": "demand_saving_level.h5",
+            "where": "/dsl",
+            "node": "block0_values"
+        },
+        "demand_saving_factor": {
+            "comment": "Demand saving as a factor of the base demand",
+            "type": "indexedarray",
+            "index_parameter": "demand_saving_level",
+            "params": [
+                {
+                    "type": "constant",
+                    "value": 1.0
+                },
+                {
+                    "type": "constant",
+                    "value": 0.8
+                },
+                {
+                    "type": "constant",
+                    "value": 0.5
+                },
+                {
+                    "type": "constant",
+                    "value": 0.25
+                }
+            ]
+        },
+        "demand_max_flow": {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                "demand_baseline",
+                "demand_saving_factor"
+            ]
+        }
+    }
+}

--- a/pywr_schema/tests/models/demand_saving_with_tables_recorder.json
+++ b/pywr_schema/tests/models/demand_saving_with_tables_recorder.json
@@ -1,0 +1,159 @@
+{
+    "metadata": {
+        "title": "Demand Saving",
+        "description": "Demand saving using an IndexedArrayParameter",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2016-01-01",
+        "end": "2016-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "type": "catchment",
+            "name": "Inflow",
+            "flow": 0.0
+        },
+        {
+            "type": "reservoir",
+            "name": "Reservoir",
+            "max_volume": 1000,
+            "initial_volume": 1000
+        },
+        {
+            "type": "output",
+            "name": "Spill",
+            "cost": 10
+        },
+        {
+            "comment": "The only demand in the model",
+            "type": "output",
+            "name": "Demand",
+            "max_flow": "demand_max_flow",
+            "cost": -500
+        }
+    ],
+    "edges": [
+        ["Inflow", "Reservoir"],
+        ["Reservoir", "Demand"],
+        ["Reservoir", "Spill"]
+    ],
+    "parameters": {
+        "demand_baseline": {
+            "type": "constant",
+            "value": 50
+        },
+        "demand_profile": {
+            "comment": "Monthly demand profile as a factor around the mean demand",
+            "type": "monthlyprofile",
+            "values": [
+                0.9,
+                0.9,
+                0.9,
+                0.9,
+                1.2,
+                1.2,
+                1.2,
+                1.2,
+                0.9,
+                0.9,
+                0.9,
+                0.9
+            ]
+        },
+        "level1": {
+            "type": "constant",
+            "value": 0.8
+        },
+        "level2": {
+            "type": "constant",
+            "value": 0.5
+        },
+        "demand_saving_level": {
+            "comment": "The demand saving level",
+            "type": "controlcurveindex",
+            "storage_node": "Reservoir",
+            "control_curves": [
+                "level1",
+                "level2"
+            ]
+        },
+        "demand_saving_factor": {
+            "comment": "Demand saving as a factor of the base demand",
+            "type": "indexedarray",
+            "index_parameter": "demand_saving_level",
+            "params": [
+                {
+                    "type": "constant",
+                    "value": 1.0
+                },
+                {
+                    "type": "monthlyprofile",
+                    "values": [
+                        0.95,
+                        0.95,
+                        0.95,
+                        0.95,
+                        0.90,
+                        0.90,
+                        0.90,
+                        0.90,
+                        0.95,
+                        0.95,
+                        0.95,
+                        0.95
+                    ]
+                },
+                {
+                    "type": "monthlyprofile",
+                    "values": [
+                        0.5,
+                        0.5,
+                        0.5,
+                        0.5,
+                        0.4,
+                        0.4,
+                        0.4,
+                        0.4,
+                        0.5,
+                        0.5,
+                        0.5,
+                        0.5
+                    ]
+                }
+            ]
+        },
+        "demand_max_flow": {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                "demand_baseline",
+                "demand_profile",
+                "demand_saving_factor"
+            ]
+        }
+    },
+    "recorders": {
+        "database": {
+            "type": "TablesRecorder",
+            "url": "output.h5",
+            "nodes": [
+                ["/outputs/demand", "Demand"],
+                ["/storage/reservoir", "Reservoir"]
+            ],
+            "parameters": [
+                ["/parameters/demand_saving_level", "demand_saving_level"]
+            ],
+            "mode": "w",
+            "filter_kwds": {
+                "complevel": 5,
+                "complib": "zlib"
+            },
+            "metadata": {
+                "author": "pytest",
+                "run_number": 0
+            }
+        }
+    }
+}

--- a/pywr_schema/tests/models/discount.json
+++ b/pywr_schema/tests/models/discount.json
@@ -1,0 +1,35 @@
+{
+    "metadata": {
+        "title": "DiscountFactorParameter test model",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2020-12-31",
+        "timestep": 10
+    },
+    "nodes": [
+        {
+            "name": "supply",
+            "type": "Input",
+            "max_flow": 10,
+            "cost": 3
+        },
+        {
+            "name": "demand",
+            "type": "Output",
+            "max_flow": "discount_factor",
+            "cost": -100
+        }
+    ],
+    "edges": [
+        ["supply", "demand"]
+    ],
+    "parameters": {
+        "discount_factor": {
+            "type": "DiscountFactorParameter",
+            "base_year": 2015,
+            "rate": 0.035
+        }
+    }
+}

--- a/pywr_schema/tests/models/extra1.json
+++ b/pywr_schema/tests/models/extra1.json
@@ -1,0 +1,36 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "includes": [
+        "extra2.json"
+    ],
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/extra2.json
+++ b/pywr_schema/tests/models/extra2.json
@@ -1,0 +1,18 @@
+{
+    "nodes": [
+        {
+            "name": "supply2",
+            "type": "Input",
+            "max_flow": "supply2_max_flow"
+        }
+    ],
+    "edges": [
+        ["supply2", "link1"]
+    ],
+    "parameters": {
+        "supply2_max_flow": {
+            "type": "constant",
+            "value": 50
+        }
+    }
+}

--- a/pywr_schema/tests/models/flow_interpolation.json
+++ b/pywr_schema/tests/models/flow_interpolation.json
@@ -1,0 +1,49 @@
+{
+    "metadata": {
+        "title": "Two_node_system",
+        "description": "A model to test InterpolatedFlowParameter",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": "M"
+    },
+    "nodes": [
+        {
+            "name": "inflow",
+            "type": "catchment",
+            "flow": 7.5
+        },
+
+        {
+            "name": "outflow",
+            "type": "Output", 
+            "max_flow": 30, 
+            "cost": -10
+        }
+
+        ],
+    "edges": [
+        ["inflow", "outflow"]
+    ],
+    "parameters":  {
+    "water_level": {
+        "type": "InterpolatedFlowParameter",
+          "node": "outflow",
+          "flows": [0,5,10],
+          "values": [3,6,8],
+          "interp_kwargs": {
+            "kind": "linear"
+          }
+        }
+    },
+    "recorders": {
+        "water_level_value": {
+            "type": "NumpyArrayParameterRecorder",
+            "parameter": "water_level"
+        }
+    }
+  
+  }
+  

--- a/pywr_schema/tests/models/flow_parameter.json
+++ b/pywr_schema/tests/models/flow_parameter.json
@@ -1,0 +1,60 @@
+{
+    "metadata": {
+        "title": "Flow",
+        "description": "Example of flow parameter",
+        "minimum_version": "1.1.1dev0"
+    },
+    "timestepper": {
+        "start": "2015-01-20",
+        "end": "2015-12-31",
+        "timestep": 31
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": {
+                "type": "monthlyprofile",
+                "values": [5, 6, 7, 8, 9, 10, 11, 12, 11, 10, 9, 8]
+            }
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "yesterday_flow",
+            "type": "input",
+            "max_flow": "flow"
+        },
+        {
+            "name": "dummy_output",
+            "type": "output",
+            "max_flow": null,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"],
+        ["yesterday_flow", "dummy_output"]
+    ],
+    "parameters": {
+        "flow": {
+            "type": "flow",
+            "node": "demand1",
+            "initial_value": 3.1415
+        }
+    },
+    "recorders": {
+        "flow_recorder": {
+            "type": "numpyarraynoderecorder",
+            "node": "demand1"
+        },
+        "yesterday_flow_recorder": {
+            "type": "numpyarraynoderecorder",
+            "node": "yesterday_flow"
+        }
+    }
+}

--- a/pywr_schema/tests/models/hydropower_example.json
+++ b/pywr_schema/tests/models/hydropower_example.json
@@ -1,0 +1,116 @@
+{
+    "metadata": {
+        "title": "Hydropower example",
+        "description": "A model with a single reservoir and hydro-power recorder",
+        "minimum_version": "0.4"
+    },
+    "timestepper": {
+        "start": "2100-01-01",
+        "end": "2101-01-01",
+        "timestep": 7
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": 100.0
+        },
+        {
+            "name": "reservoir1",
+            "type": "storage",
+            "max_volume": 200000,
+            "initial_volume": 170000
+        },
+        {
+            "name": "release1",
+            "type": "link",
+            "max_flow": 10,
+            "cost": -500
+        },
+        {
+            "name": "turbine1",
+            "type": "link",
+            "max_flow": "turbine1_discharge",
+            "cost": -200
+        },
+        {
+            "name": "spill1",
+            "type": "link",
+            "cost": 1000
+        },
+        {
+            "name": "reach1",
+            "type": "link"
+        },
+        {
+            "name": "end1",
+            "type": "output"
+        }
+    ],
+    "edges": [
+        ["catchment1", "reservoir1"],
+        ["reservoir1", "release1"],
+        ["reservoir1", "turbine1"],
+        ["reservoir1", "spill1"],
+        ["release1", "reach1"],
+        ["turbine1", "reach1"],
+        ["spill1", "reach1"],
+        ["reach1", "end1"]
+    ],
+    "parameters": {
+        "reservoir1_level": {
+          "type": "interpolatedvolume",
+          "node": "reservoir1",
+          "volumes": [0, 25000, 50000, 75000, 100000, 150000, 200000],
+          "values": [0, 29.2, 36.8, 42.2, 46.4, 53.1, 58.5],
+          "interp_kwargs": {
+            "kind": "cubic"
+          }
+        },
+        "turbine1_discharge": {
+            "type": "indexedarray",
+            "index_parameter": "turbine1_control",
+            "params": [
+                40.0,
+                0.0
+            ]
+        },
+        "turbine1_control": {
+            "type": "controlcurveindex",
+            "storage_node": "reservoir1",
+            "control_curves": [
+                "turbine1_control_curve"
+            ]
+        },
+        "turbine1_control_curve": {
+            "type": "monthlyprofile",
+            "values": [0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8]
+        }
+    },
+    "recorders": {
+        "turbine1_energy": {
+            "type": "HydroPowerRecorder",
+            "node": "turbine1",
+            "water_elevation_parameter": "reservoir1_level",
+            "turbine_elevation": 35.0,
+            "efficiency": 0.85,
+            "flow_unit_conversion": 1e3
+        },
+        "catchment1_flow": {
+            "type": "numpyarraynoderecorder",
+            "node": "catchment1"
+        },
+        "reservoir1_storage": {
+            "type": "numpyarraystoragerecorder",
+            "node": "reservoir1"
+        },
+        "turbine1_flow": {
+            "type": "numpyarraynoderecorder",
+            "node": "turbine1"
+        },
+        "release1_flow": {
+            "type": "numpyarraynoderecorder",
+            "node": "release1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/hydropower_target_example.json
+++ b/pywr_schema/tests/models/hydropower_target_example.json
@@ -1,0 +1,107 @@
+{
+    "metadata": {
+        "title": "Hydropower example",
+        "description": "A model with a single reservoir and hydro-power recorder",
+        "minimum_version": "0.6"
+    },
+    "timestepper": {
+        "start": "2100-01-01",
+        "end": "2101-01-01",
+        "timestep": 7
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": 0.0
+        },
+        {
+            "name": "reservoir1",
+            "type": "storage",
+            "max_volume": 200000,
+            "initial_volume": 200000
+        },
+        {
+            "name": "release1",
+            "type": "link",
+            "max_flow": 10,
+            "cost": -500
+        },
+        {
+            "name": "turbine1",
+            "type": "link",
+            "max_flow": "turbine1_discharge",
+            "cost": -200
+        },
+        {
+            "name": "spill1",
+            "type": "link",
+            "cost": 1000
+        },
+        {
+            "name": "reach1",
+            "type": "link"
+        },
+        {
+            "name": "end1",
+            "type": "output"
+        }
+    ],
+    "edges": [
+        ["catchment1", "reservoir1"],
+        ["reservoir1", "release1"],
+        ["reservoir1", "turbine1"],
+        ["reservoir1", "spill1"],
+        ["release1", "reach1"],
+        ["turbine1", "reach1"],
+        ["spill1", "reach1"],
+        ["reach1", "end1"]
+    ],
+    "parameters": {
+        "reservoir1_level": {
+          "type": "interpolatedvolume",
+          "node": "reservoir1",
+          "volumes": [0, 25000, 50000, 75000, 100000, 150000, 200000],
+          "values": [0, 29.2, 36.8, 42.2, 46.4, 53.1, 58.5],
+          "interp_kwargs": { 
+            "kind": "cubic"
+          }
+        },
+        "turbine1_discharge": {
+            "type": "HydroPowerTarget",
+            "water_elevation_parameter": "reservoir1_level",
+            "turbine_elevation": 35.0,
+            "efficiency": 0.85,
+            "flow_unit_conversion": 1e3,
+            "target": { "type": "constant", "value": 1e5},
+            "max_flow": { "type": "constant", "value": 1000.0},
+            "min_flow": { "type": "constant", "value": 500.0}
+        }
+    },
+    "recorders": {
+        "turbine1_energy": {
+            "type": "HydroPowerRecorder",
+            "node": "turbine1",
+            "water_elevation_parameter": "reservoir1_level",
+            "turbine_elevation": 35.0,
+            "efficiency": 0.85,
+            "flow_unit_conversion": 1e3
+        },
+        "catchment1_flow": {
+            "type": "numpyarraynoderecorder",
+            "node": "catchment1"
+        },
+        "reservoir1_storage": {
+            "type": "numpyarraystoragerecorder",
+            "node": "reservoir1"
+        },
+        "turbine1_flow": {
+            "type": "numpyarraynoderecorder",
+            "node": "turbine1"
+        },
+        "release1_flow": {
+            "type": "numpyarraynoderecorder",
+            "node": "release1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/loss_link.json
+++ b/pywr_schema/tests/models/loss_link.json
@@ -1,0 +1,35 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example with losses.",
+        "minimum_version": "1.11.0"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "cost": 0.1
+        },
+        {
+            "name": "link1",
+            "type": "LossLink",
+            "max_flow": 10,
+            "loss_factor": 0.2
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 20,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/mean_flow_parameter.json
+++ b/pywr_schema/tests/models/mean_flow_parameter.json
@@ -1,0 +1,73 @@
+{
+    "metadata": {
+        "title": "Mean flow parameter",
+        "description": "A test of the mean flow parameter",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-04",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15,
+            "cost": 1
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+          "name": "supply2",
+          "type": "Input",
+          "max_flow": 100,
+          "cost": 0
+        },
+        {
+            "name": "demand_with_threshold",
+            "type": "Output",
+            "max_flow": {
+                "type": "parameterthreshold",
+                "parameter": "mean-flow",
+                "threshold": 2.5,
+                "values": [60.0, 50.0],
+                "predicate": "LT"
+            },
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"],
+        ["supply2", "demand_with_threshold"]
+    ],
+    "parameters": {
+        "mean-flow": {
+            "comment": "Mean flow (last 3 days) from supply1",
+            "type": "RollingMeanFlowNode",
+            "node": "supply1",
+            "timesteps": 3
+        }
+
+    },
+    "recorders": {
+        "Supply": {
+            "comment": "Actual flow from supply1",
+            "type": "NumpyArrayNode",
+            "node": "supply1"
+        },
+        "Mean Flow": {
+            "comment": "Mean flow (last 3 days) from supply1",
+            "type": "NumpyArrayParameter",
+            "parameter": "mean-flow"
+        },
+        "Supply 2": {
+            "type": "NumpyArrayNode",
+            "node": "supply2"
+        }
+    }
+}

--- a/pywr_schema/tests/models/mean_flow_recorder.json
+++ b/pywr_schema/tests/models/mean_flow_recorder.json
@@ -1,0 +1,65 @@
+{
+    "metadata": {
+        "title": "Mean flow recorder",
+        "description": "A test of recorders in JSON",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-04",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15,
+            "cost": 1
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+          "name": "supply2",
+          "type": "Input",
+          "max_flow": 100,
+          "cost": 0
+        },
+        {
+            "name": "demand_with_threshold",
+            "type": "Output",
+            "max_flow": {
+                "type": "recorderthreshold",
+                "recorder": "Mean Flow",
+                "threshold": 2.5,
+                "values": [60.0, 50.0],
+                "predicate": "LT"
+            },
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"],
+        ["supply2", "demand_with_threshold"]
+    ],
+    "recorders": {
+        "Supply": {
+            "comment": "Actual flow from supply1",
+            "type": "NumpyArrayNode",
+            "node": "supply1"
+        },
+        "Mean Flow": {
+            "comment": "Mean flow (last 3 days) from supply1",
+            "type": "rollingMeanFlownode",
+            "node": "supply1",
+            "timesteps": 3
+        },
+        "Supply 2": {
+            "type": "NumpyArrayNode",
+            "node": "supply2"
+        }
+    }
+}

--- a/pywr_schema/tests/models/multiindex_df.json
+++ b/pywr_schema/tests/models/multiindex_df.json
@@ -1,0 +1,45 @@
+{
+    "metadata": {
+        "title": "Multiindex 1",
+        "description": "An example of loading a multi-index parameter.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": {
+                "type": "constant",
+                "url": "multiindex_data.csv",
+                "column": "max_flow",
+                "index": [0, "demand1"],
+                "index_col": ["level", "node"]
+            },
+            "cost": {
+                "type": "constant",
+                "url": "multiindex_data.csv",
+                "column": "cost",
+                "index": [1, "demand1"],
+                "index_col": ["level", "node"]
+            }
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/parameter_recorder.json
+++ b/pywr_schema/tests/models/parameter_recorder.json
@@ -1,0 +1,50 @@
+{
+    "metadata": {
+        "title": "Parameter recorder",
+        "description": "JSON example of parameter recorder",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": "supply_max"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": "demand_max",
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"]
+    ],
+    "parameters": {
+        "demand_max": {
+            "type": "constant",
+            "values": 10
+        },
+        "supply_max": {
+            "type": "constant",
+            "values": 15,
+            "name": "supply_max"
+        }
+    },
+    "recorders": {
+        "demand_max_recorder": {
+            "type": "NumpyArrayParameterRecorder",
+            "parameter": "demand_max"
+        },
+        "supply_max_recorder": {
+            "type": "NumpyArrayParameterRecorder",
+            "node": "supply1",
+            "parameter": "supply_max"
+        }
+    }
+}

--- a/pywr_schema/tests/models/parameter_reference.json
+++ b/pywr_schema/tests/models/parameter_reference.json
@@ -1,0 +1,52 @@
+{
+    "metadata": {
+        "title": "Parameter reference",
+        "description": "Most basic example of parameter references",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": "supply_max_flow",
+            "cost": {
+                "type": "constant",
+                "values": 0.0
+            }
+        },
+        {
+            "name": "link1",
+            "type": "link",
+            "max_flow": {
+                "name": "link_max_flow",
+                "type": "constant",
+                "values": 9999
+            }
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": "demand_cost"
+        }
+    ],
+    "parameters": {
+        "supply_max_flow": {
+            "type": "constant",
+            "values": 125.0
+        },
+        "demand_cost": {
+            "type": "constant",
+            "values": -10
+        }
+    },
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/piecewise1.json
+++ b/pywr_schema/tests/models/piecewise1.json
@@ -1,0 +1,36 @@
+{
+    "metadata": {
+        "title": "Piecewise link",
+        "description": "Example of a piecewise link",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100
+        },
+        {
+            "name": "link1",
+            "type": "piecewiselink",
+            "nsteps": 2,
+            "costs": [-10.0, 5.0],
+            "max_flows": [20.0, null]
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 50,
+            "cost": 0.0
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/piecewise1_with_parameters.json
+++ b/pywr_schema/tests/models/piecewise1_with_parameters.json
@@ -1,0 +1,50 @@
+{
+    "metadata": {
+        "title": "Piecewise link with parameters",
+        "description": "Example of a piecewise link that uses parameters",
+        "minimum_version": "1.2.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100
+        },
+        {
+            "name": "link1",
+            "type": "piecewiselink",
+            "nsteps": 2,
+            "costs": ["cost1", "cost2"],
+            "max_flows": ["max_flow1", null]
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 50,
+            "cost": 0.0
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "cost1": {
+            "type": "constant",
+            "value": -10.0
+        },
+        "cost2": {
+            "type": "constant",
+            "value": 5.0
+        },
+        "max_flow1": {
+            "type": "constant",
+            "value": 20.0
+        }
+    }
+}

--- a/pywr_schema/tests/models/python_include.json
+++ b/pywr_schema/tests/models/python_include.json
@@ -1,0 +1,39 @@
+{
+    "metadata": {
+        "title": "Python include",
+        "description": "An example of including a Python file to define a custom parameter.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "includes": [
+        "my_parameter.py"
+    ],
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": {
+                "type": "MyParameter",
+                "value": 15
+            }
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/reservoir1.json
+++ b/pywr_schema/tests/models/reservoir1.json
@@ -1,0 +1,35 @@
+{
+    "metadata": {
+        "title": "Reservoir 1",
+        "description": "A model with a reservoir.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Storage",
+            "max_volume": 35,
+            "initial_volume": 35,
+            "outputs": 0
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/reservoir1_pc.json
+++ b/pywr_schema/tests/models/reservoir1_pc.json
@@ -1,0 +1,35 @@
+{
+    "metadata": {
+        "title": "Reservoir 1",
+        "description": "A model with a reservoir.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Storage",
+            "max_volume": 35,
+            "initial_volume_pc": 1.0,
+            "outputs": 0
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/reservoir2.json
+++ b/pywr_schema/tests/models/reservoir2.json
@@ -1,0 +1,61 @@
+{
+    "metadata": {
+        "title": "Reservoir 2",
+        "description": "Model with a reservoir, fed by a river abstraction",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Storage",
+            "max_volume": {
+                "type": "constant",
+                "value": 35
+            },
+            "min_volume": {
+                "type": "constant",
+                "value": 0
+            },
+            "initial_volume": 35,
+            "initial_volume_pc": 1.0
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 15,
+            "cost": -10
+        },
+        {
+            "name": "catchment1",
+            "type": "Input",
+            "max_flow": 5,
+            "min_flow": 5
+        },
+        {
+            "name": "abs1",
+            "type": "Link",
+            "max_flow": 5
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": 1
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"],
+        ["catchment1", "abs1"],
+        ["abs1", "supply1"],
+        ["abs1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/reservoir_evaporation.json
+++ b/pywr_schema/tests/models/reservoir_evaporation.json
@@ -1,0 +1,62 @@
+{
+    "metadata": {
+        "title": "Reservoir Evaporation",
+        "description": "A model with a reservoir, with evaporation proportional to surface area",
+        "minimum_version": "0.5dev0"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "max_volume": 1000,
+            "initial_volume": 1000,
+            "area": "reservoir_area",
+            "outputs": 0
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "evaporation",
+            "type": "Output",
+            "max_flow": "reservoir_evaporation",
+            "cost": -1000
+        }        
+    ],
+    "edges": [
+        ["reservoir1", "evaporation"],
+        ["reservoir1", "demand1"]
+    ],
+    "parameters": {
+        "reservoir_area": {
+            "type": "interpolatedvolume",
+            "node": "reservoir1",
+            "volumes": [0, 1000],
+            "values": [0, 500],
+            "interp_kwargs": {  
+                "kind": "linear"
+              }
+        },
+        "evaporation_mm": {
+            "type": "monthlyprofile",
+            "values": [5.0, 5.0, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0, 5.0, 5.0, 5.0, 5.0]
+        },
+        "reservoir_evaporation": {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                "reservoir_area",
+                "evaporation_mm",
+                0.001
+            ]
+        }
+    }
+}

--- a/pywr_schema/tests/models/reservoir_evaporation_areafromfile.json
+++ b/pywr_schema/tests/models/reservoir_evaporation_areafromfile.json
@@ -1,0 +1,67 @@
+{
+    "metadata": {
+        "title": "Reservoir Evaporation with area-volume curve from file",
+        "description": "A model with a reservoir, with evaporation proportional to surface area in a external file",
+        "minimum_version": "0.5dev0"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "max_volume": 1000,
+            "initial_volume": 1000,
+            "outputs": 0
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "evaporation",
+            "type": "Output",
+            "max_flow": "reservoir_evaporation",
+            "cost": -1000
+        }        
+    ],
+    "edges": [
+        ["reservoir1", "evaporation"],
+        ["reservoir1", "demand1"]
+    ],
+    "parameters": {
+        "reservoir_area": {
+            "type": "interpolatedvolume",
+            "node": "reservoir1",
+            "volumes": {
+                "url": "reservoirarea.csv",
+                "column": "volumes"
+              },
+              "values": {
+                "url": "reservoirarea.csv",
+                "column": "values"
+              },
+            "interp_kwargs": {  
+              "kind": "linear"
+            }
+        },
+        "evaporation_mm": {
+            "type": "monthlyprofile",
+            "values": [5.0, 5.0, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0, 5.0, 5.0, 5.0, 5.0]
+        },
+        "reservoir_evaporation": {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                "reservoir_area",
+                "evaporation_mm",
+                0.001
+            ]
+        }
+    }
+}

--- a/pywr_schema/tests/models/reservoir_evaporation_without_area_property.json
+++ b/pywr_schema/tests/models/reservoir_evaporation_without_area_property.json
@@ -1,0 +1,61 @@
+{
+    "metadata": {
+        "title": "Reservoir Evaporation",
+        "description": "A model with a reservoir, with evaporation proportional to surface area",
+        "minimum_version": "0.5dev0"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "max_volume": 1000,
+            "initial_volume": 1000,
+            "outputs": 0
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "evaporation",
+            "type": "Output",
+            "max_flow": "reservoir_evaporation",
+            "cost": -1000
+        }        
+    ],
+    "edges": [
+        ["reservoir1", "evaporation"],
+        ["reservoir1", "demand1"]
+    ],
+    "parameters": {
+        "reservoir_area": {
+            "type": "interpolatedvolume",
+            "node": "reservoir1",
+            "volumes": [0, 1000],
+            "values": [0, 500],
+            "interp_kwargs": {  
+                "kind": "linear"
+              }
+        },
+        "evaporation_mm": {
+            "type": "monthlyprofile",
+            "values": [5.0, 5.0, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0, 5.0, 5.0, 5.0, 5.0]
+        },
+        "reservoir_evaporation": {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                "reservoir_area",
+                "evaporation_mm",
+                0.001
+            ]
+        }
+    }
+}

--- a/pywr_schema/tests/models/reservoir_initial_vol_from_table.json
+++ b/pywr_schema/tests/models/reservoir_initial_vol_from_table.json
@@ -1,0 +1,58 @@
+{
+    "metadata": {
+        "title": "Reservoir 1",
+        "description": "Reservoirs initial volume from table",
+        "minimum_version": "0.4"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Storage",
+            "max_volume": 35,
+            "initial_volume": {
+                "table": "initial_volumes",
+                "column": "Initial Volume",
+                "index": "supply1"
+            },
+            "outputs": 0
+        },
+        {
+            "name": "supply2",
+            "type": "Storage",
+            "max_volume": 35,
+            "initial_volume": {
+                "table": "initial_volumes",
+                "column": "Initial Volume",
+                "index": "supply2"
+            },
+            "outputs": 0
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["supply2", "link1"],
+        ["link1", "demand1"]
+    ],
+    "tables": {
+        "initial_volumes": {
+            "url": "initial_volumes.csv",
+            "index_col": 0,
+            "header": 0
+        }
+    }
+}

--- a/pywr_schema/tests/models/reservoir_net_abstraction.json
+++ b/pywr_schema/tests/models/reservoir_net_abstraction.json
@@ -1,0 +1,42 @@
+{
+    "metadata": {
+        "title": "Reservoir 1",
+        "description": "Constraint on net abstraction.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "in",
+            "type": "Input",
+            "max_flow": 2
+        },
+        {
+            "name": "r",
+            "type": "Storage",
+            "max_volume": 35,
+            "initial_volume": 35
+        },
+        {
+            "name": "out",
+            "type": "Output",
+            "max_flow": 100,
+            "cost": -10
+        },
+        {
+            "name": "net_abs",
+            "type": "aggregatednode",
+            "nodes": ["in", "out"],
+            "max_flow": 10,
+            "flow_weights": [-1, 1]
+        }
+    ],
+    "edges": [
+        ["in", "r"],
+        ["r", "out"]
+    ]
+}

--- a/pywr_schema/tests/models/reservoir_with_cc.json
+++ b/pywr_schema/tests/models/reservoir_with_cc.json
@@ -1,0 +1,41 @@
+{
+    "metadata": {
+        "title": "Reservoir with cc",
+        "description": "A model with a reservoir and control curve",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "max_volume": 1000,
+            "initial_volume": 1000,
+            "outputs": 0,
+            "cost": {
+                "type": "ControlCurveInterpolated",
+                "control_curve": {
+                    "type": "dailyprofile",
+                    "url": "control_curve.csv",
+                    "parse_dates": false,
+                    "column": "Control Curve"
+                },
+                "storage_node": "reservoir1",
+                "values": [-8, -6, -4]
+            }
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 300,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["reservoir1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/reservoir_with_cc_param_values.json
+++ b/pywr_schema/tests/models/reservoir_with_cc_param_values.json
@@ -1,0 +1,45 @@
+{
+    "metadata": {
+        "title": "Reservoir with cc",
+        "description": "A model with a reservoir and control curve",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "max_volume": 1000,
+            "initial_volume": 1000,
+            "outputs": 0,
+            "cost": {
+                "type": "ControlCurveInterpolated",
+                "control_curve": {
+                    "type": "dailyprofile",
+                    "url": "control_curve.csv",
+                    "parse_dates": false,
+                    "column": "Control Curve"
+                },
+                "storage_node": "reservoir1",
+                "parameters": [
+                    {"type": "constant", "value":  -8},
+                    {"type": "constant", "value":  -6},
+                    {"type": "constant", "value":  -4}
+                ]
+            }
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 300,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["reservoir1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/reservoir_with_circular_cc.json
+++ b/pywr_schema/tests/models/reservoir_with_circular_cc.json
@@ -1,0 +1,44 @@
+{
+    "metadata": {
+        "title": "A model with a circular reference on the storage node.",
+        "description": "This is a simple demonstration of a circular reference problem with group control curves. See github issue #380: https://github.com/pywr/pywr/issues/380",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "max_volume": 1000,
+            "initial_volume": 1000,
+            "outputs": 0,
+            "cost": "reservoir1_cost"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 300,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["reservoir1", "demand1"]
+    ],
+    "parameters": {
+        "reservoir1_cost": {
+                "type": "ControlCurveInterpolated",
+                "control_curve": {
+                    "type": "dailyprofile",
+                    "url": "control_curve.csv",
+                    "parse_dates": false,
+                    "column": "Control Curve"
+                },
+                "storage_node": "reservoir1",
+                "values": [-8, -6, -4]
+            }
+    }
+}

--- a/pywr_schema/tests/models/river1.json
+++ b/pywr_schema/tests/models/river1.json
@@ -1,0 +1,49 @@
+{
+    "metadata": {
+        "title": "River 1",
+        "description": "A model with a river abstraction.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": 5
+        },
+        {
+            "name": "river1",
+            "type": "river"
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "river"
+        },
+        {
+            "name": "term1",
+            "type": "output"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "link1"],
+        ["link1", "demand1"],
+        ["abs1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/river2.json
+++ b/pywr_schema/tests/models/river2.json
@@ -1,0 +1,75 @@
+{
+    "metadata": {
+        "title": "River 1",
+        "description": "A more complex river system.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": 5
+        },
+        {
+            "name": "catchment2",
+            "type": "catchment",
+            "flow": 5
+        },
+        {
+            "name": "river1",
+            "type": "river"
+        },
+        {
+            "name": "river2",
+            "type": "riversplit",
+            "factors": [1, 3],
+            "slot_names": ["term", "branch"]
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 15
+        },
+        {
+            "name": "abs2",
+            "type": "link",
+            "max_flow": 15
+        },
+        {
+            "name": "term1",
+            "type": "output"
+        },
+        {
+            "name": "term2",
+            "type": "output"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "demand2",
+            "type": "Output",
+            "max_flow": 2,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["catchment2", "abs2"],
+        ["abs2", "river2"],
+        ["abs2", "demand2"],
+        ["river2", "river1", "branch", null],
+        ["river2", "term2", "term", null],
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "demand1"],
+        ["abs1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/river_discharge1.json
+++ b/pywr_schema/tests/models/river_discharge1.json
@@ -1,0 +1,55 @@
+{
+    "metadata": {
+        "title": "River Discharge 1",
+        "description": "A model with a discharge upstream from an abstraction.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": 5
+        },
+        {
+            "name": "discharge1",
+            "type": "input",
+            "min_flow": 3,
+            "max_flow": 3
+        },
+        {
+            "name": "river1",
+            "type": "link"
+        },
+        {
+            "name": "abs1",
+            "type": "link"
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "output"
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "discharge1"],
+        ["discharge1", "abs1"],
+        ["abs1", "link1"],
+        ["link1", "demand1"],
+        ["abs1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/river_discharge2.json
+++ b/pywr_schema/tests/models/river_discharge2.json
@@ -1,0 +1,55 @@
+{
+    "metadata": {
+        "title": "River Discharge 2",
+        "description": "A model with a discharge upstream from an abstraction.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": 5
+        },
+        {
+            "name": "discharge1",
+            "type": "input",
+            "min_flow": 3,
+            "max_flow": 3
+        },
+        {
+            "name": "river1",
+            "type": "link"
+        },
+        {
+            "name": "abs1",
+            "type": "link"
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "output"
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "link1"],
+        ["link1", "demand1"],
+        ["abs1", "discharge1"],
+        ["discharge1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/river_mrf1.json
+++ b/pywr_schema/tests/models/river_mrf1.json
@@ -1,0 +1,48 @@
+{
+    "metadata": {
+        "title": "River with MRF",
+        "description": "Example of a minimum residual flow constraint",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "catchment",
+            "type": "catchment",
+            "flow": 100
+        },
+        {
+            "name": "river",
+            "type": "river"
+        },
+        {
+            "name": "mrf",
+            "type": "rivergauge",
+            "mrf": {
+                "type": "monthlyprofile",
+                "values": [20, 20, 20, 20, 20, 60, 60, 60, 60, 60, 20, 20]
+            },
+            "mrf_cost": -1000
+        },
+        {
+            "name": "waste",
+            "type": "output"
+        },
+        {
+            "name": "demand",
+            "type": "output",
+            "max_flow": 200,
+            "cost": -500
+        }
+    ],
+    "edges": [
+        ["catchment", "river"],
+        ["river", "mrf"],
+        ["mrf", "waste"],
+        ["river", "demand"]
+    ]
+}

--- a/pywr_schema/tests/models/river_split_with_gauge1.json
+++ b/pywr_schema/tests/models/river_split_with_gauge1.json
@@ -1,0 +1,45 @@
+{
+    "metadata": {
+        "title": "RiverSplitWithGauge",
+        "description": "Example of an abstraction with an MRF of form y=mx+c",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "Catchment",
+            "type": "catchment",
+            "flow": 100
+        },
+        {
+            "name": "Gauge",
+            "type": "RiverSplitWithGauge",
+            "mrf": {
+                "type": "monthlyprofile",
+                "values": [40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0]
+            },
+            "mrf_cost": -1000,
+            "factors": [3, 1],
+            "slot_names": ["river", "abstraction"]
+        },
+        {
+            "name": "Estuary",
+            "type": "output"
+        },
+        {
+            "name": "Demand",
+            "type": "Output",
+            "max_flow": 50,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["Catchment", "Gauge"],
+        ["Gauge", "Estuary", "river", null],
+        ["Gauge", "Demand", "abstraction", null]
+    ]
+}

--- a/pywr_schema/tests/models/rolling_virtual_storage.json
+++ b/pywr_schema/tests/models/rolling_virtual_storage.json
@@ -1,0 +1,44 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage",
+        "description": "Rolling abstraction licence implemented as a rolling virtual storage",
+        "minimum_version": "1.10"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "Input",
+            "type": "Input",
+            "max_flow": 20,
+            "cost": 0
+        },
+        {
+            "name": "Link",
+            "type": "Link"
+        },
+        {
+            "name": "Output",
+            "type": "Output",
+            "max_flow": 15,
+            "cost": -10
+        },
+        {
+            "name": "Licence",
+            "type": "RollingVirtualStorage",
+            "max_volume": 30,
+            "initial_volume": 30,
+            "nodes": [
+                "Link"
+            ],
+            "days": 3
+        }
+    ],
+    "edges": [
+        ["Input", "Link"],
+        ["Link", "Output"]
+    ]
+}

--- a/pywr_schema/tests/models/scenario_monthly_profile.json
+++ b/pywr_schema/tests/models/scenario_monthly_profile.json
@@ -1,0 +1,58 @@
+{
+    "metadata": {
+        "title": "Scenario monthly profile",
+        "description": "A simple example to test ScenarioMonthlyProfileParameter",
+        "minimum_version": "0.2dev"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 3
+        }
+    ],
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": {
+                "type": "aggregated",
+                "agg_func": "product",
+                "parameters": [
+                    {
+                        "type": "dataframe",
+                        "url" : "timeseries1.csv",
+                        "parse_dates": true,
+                        "dayfirst": true,
+                        "index_col": 0
+                    },
+                    {
+                        "type": "scenariomonthlyprofile",
+                        "url": "monthly_profiles.csv",
+                        "scenario": "scenario A",
+                        "index_col": 0
+                    }
+
+                ]
+            }
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10000,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/scenario_with_slices.json
+++ b/pywr_schema/tests/models/scenario_with_slices.json
@@ -1,0 +1,33 @@
+{
+    "metadata": {
+        "title": "Scenario with slices",
+        "description": "Example of scenario with slices",
+        "minimum_version": "0.2dev"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10,
+            "slice": [0, null, 2]
+        },
+        {
+            "name": "scenario B",
+            "size": 2,
+            "slice": [0, 1, 1]
+        }
+    ],
+    "nodes": [
+
+    ],
+    "edges": [
+
+    ],
+    "recorders": {
+
+    }
+}

--- a/pywr_schema/tests/models/scenario_with_user_combinations.json
+++ b/pywr_schema/tests/models/scenario_with_user_combinations.json
@@ -1,0 +1,38 @@
+{
+    "metadata": {
+        "title": "Scenario with slices",
+        "description": "Example of scenario with slices",
+        "minimum_version": "0.2dev"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10,
+            "slice": [0, null, 2]
+        },
+        {
+            "name": "scenario B",
+            "size": 2,
+            "slice": [0, 1, 1]
+        }
+    ],
+    "scenario_combinations": [
+        [0, 0],
+        [0, 1],
+        [5, 1]
+    ],
+    "nodes": [
+
+    ],
+    "edges": [
+
+    ],
+    "recorders": {
+
+    }
+}

--- a/pywr_schema/tests/models/seasonal_virtual_storage.json
+++ b/pywr_schema/tests/models/seasonal_virtual_storage.json
@@ -1,0 +1,60 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage",
+        "description": "Annual abstraction licence implemented as an annual virtual storage",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2016-02-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100,
+            "cost": 0
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "licence1",
+            "type": "SeasonalVirtualStorage",
+            "max_volume": 100,
+            "initial_volume": 100,
+            "nodes": [
+                "supply1"
+            ],
+            "factors": [
+                1.0
+            ],
+            "reset_day": 1,
+            "reset_month": 1,
+            "end_day": 31,
+            "end_month": 1
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        },
+        "licence1":{
+            "type": "numpyarraystoragerecorder",
+            "node": "licence1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/simple1.json
+++ b/pywr_schema/tests/models/simple1.json
@@ -1,0 +1,33 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/simple1_bisect.json
+++ b/pywr_schema/tests/models/simple1_bisect.json
@@ -1,0 +1,66 @@
+{
+    "metadata": {
+        "title": "Simple 1 bisection",
+        "description": "A very simple example of bisection.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "bisection": {
+        "parameter": "demand",
+        "epsilon": 1.0,
+        "error_on_infeasible": false
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": "supply"
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": "demand",
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "demand": {
+            "type": "ConstantParameter",
+            "value": 10.0,
+            "upper_bounds": 20.0,
+            "lower_bounds": 0.0,
+            "is_variable": false
+        },
+        "supply": {
+            "type": "ConstantParameter",
+            "value": 17.5,
+            "upper_bounds": 20.0,
+            "lower_bounds": 0.0,
+            "is_variable": true
+        }
+    },
+    "recorders": {
+        "deficit": {
+            "type": "TotalDeficitNodeRecorder",
+            "node": "demand1",
+            "constraint_upper_bounds": 0.0
+        },
+        "cost": {
+            "type": "MeanFlowNodeRecorder",
+            "node": "supply1",
+            "is_objective": "minimise"
+        }
+    }
+}

--- a/pywr_schema/tests/models/simple1_broken.json
+++ b/pywr_schema/tests/models/simple1_broken.json
@@ -1,0 +1,32 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"]
+    ]
+}

--- a/pywr_schema/tests/models/simple1_infeasible_bisect.json
+++ b/pywr_schema/tests/models/simple1_infeasible_bisect.json
@@ -1,0 +1,65 @@
+{
+    "metadata": {
+        "title": "Simple 1 bisection",
+        "description": "A very simple example of bisection.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "bisection": {
+        "parameter": "demand",
+        "epsilon": 1.0
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": "supply"
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": "demand",
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "demand": {
+            "type": "ConstantParameter",
+            "value": 20.0,
+            "upper_bounds": 30.0,
+            "lower_bounds": 20.0,
+            "is_variable": false
+        },
+        "supply": {
+            "type": "ConstantParameter",
+            "value": 17.5,
+            "upper_bounds": 10.0,
+            "lower_bounds": 0.0,
+            "is_variable": true
+        }
+    },
+    "recorders": {
+        "deficit": {
+            "type": "TotalDeficitNodeRecorder",
+            "node": "demand1",
+            "constraint_upper_bounds": 0.0
+        },
+        "cost": {
+            "type": "MeanFlowNodeRecorder",
+            "node": "supply1",
+            "is_objective": "minimise"
+        }
+    }
+}

--- a/pywr_schema/tests/models/simple1_monthly.json
+++ b/pywr_schema/tests/models/simple1_monthly.json
@@ -1,0 +1,33 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "Example of monthly period timestep.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": "M"
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/simple1_semi_broken.json
+++ b/pywr_schema/tests/models/simple1_semi_broken.json
@@ -1,0 +1,43 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "supply2",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link2",
+            "type": "Link"
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"],
+        ["supply2", "link2"]
+    ]
+}

--- a/pywr_schema/tests/models/simple_df.json
+++ b/pywr_schema/tests/models/simple_df.json
@@ -1,0 +1,45 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": {
+                "type": "constant",
+                "url": "simple_data.csv",
+                "column": "max_flow",
+                "index": "demand1",
+                "index_col": "node"
+            },
+            "cost": {
+                "type": "constant",
+                "url": "simple_data.csv",
+                "column": "cost",
+                "index": "demand1",
+                "index_col": "node"
+            }
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/simple_df_shared.json
+++ b/pywr_schema/tests/models/simple_df_shared.json
@@ -1,0 +1,49 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example using an external data file shared between two parameters.",
+        "minimum_version": "0.2dev"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": {
+                "type": "constant",
+                "table": "simple_data",
+                "column": "max_flow",
+                "index": "demand1"
+            },
+            "cost": {
+                "type": "constant",
+                "table": "simple_data",
+                "column": "cost",
+                "index": "demand1"
+            }
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "tables": {
+        "simple_data": {
+            "url": "simple_data.csv",
+            "index_col": "node"
+        }
+    }
+}

--- a/pywr_schema/tests/models/simple_with_scenario.json
+++ b/pywr_schema/tests/models/simple_with_scenario.json
@@ -1,0 +1,59 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10
+        },
+        {
+            "name": "scenario B",
+            "size": 2,
+            "ensemble_names": ["First", "Second"]
+        }
+    ],
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": {
+                "type": "constantscenario",
+                "scenario": "scenario A",
+                "values": [10, 11, 12, 13, 14, 15, 16, 17, 18 , 19]
+            }
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": {
+                "type": "constantscenario",
+                "scenario": "scenario B",
+                "values": [10, 15]
+            },
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "recorders": {
+        "demand1": {
+            "comment": "Actual flow to demand1",
+            "type": "NumpyArrayNode",
+            "node": "demand1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/simple_with_scenario_wrapper.json
+++ b/pywr_schema/tests/models/simple_with_scenario_wrapper.json
@@ -1,0 +1,73 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10
+        },
+        {
+            "name": "scenario B",
+            "size": 2,
+            "ensemble_names": ["First", "Second"]
+        }
+    ],
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": "supply1_max_flow"
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": {
+                "type": "constantscenario",
+                "scenario": "scenario B",
+                "values": [10, 15]
+            },
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "supply1_max_flow": {
+            "type": "scenariowrapper",
+            "scenario": "scenario A",
+            "parameters": [
+                {"type": "constant", "value": 10},
+                {"type": "constant", "value": 11},
+                {"type": "constant", "value": 12},
+                {"type": "constant", "value": 13},
+                {"type": "constant", "value": 14},
+                {"type": "constant", "value": 15},
+                {"type": "constant", "value": 16},
+                {"type": "constant", "value": 17},
+                {"type": "constant", "value": 18},
+                {"type": "constant", "value": 19}
+            ]
+        }
+    },
+    "recorders": {
+        "demand1": {
+            "comment": "Actual flow to demand1",
+            "type": "NumpyArrayNode",
+            "node": "demand1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/storage_parameter.json
+++ b/pywr_schema/tests/models/storage_parameter.json
@@ -1,0 +1,63 @@
+{
+    "metadata": {
+        "title": "StorageParameter test",
+        "description": "A model that demonstrates StorageParameter by making demand 10% of current volume.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-06",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Storage",
+            "max_volume": 35,
+            "initial_volume": 35,
+            "outputs": 0
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": "demand",
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "demand": {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                "storage",
+                "demand_factor"
+            ]
+        },
+        "storage": {
+            "type": "storage",
+            "storage_node": "supply1"
+        },
+        "demand_factor": {
+            "type": "constant",
+            "value": 0.1
+        }
+    },
+    "recorders": {
+        "flow_recorder": {
+            "type": "numpyarraynoderecorder",
+            "node": "demand1"
+        },
+        "storage_recorder": {
+            "type": "numpyarraystoragerecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/three_storage.json
+++ b/pywr_schema/tests/models/three_storage.json
@@ -1,0 +1,94 @@
+{
+    "metadata": {
+        "title": "Reservoir 1",
+        "description": "A model with three reservoirs and an aggregated storage node.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+      {
+        "name": "Input 0",
+        "type": "input",
+        "max_flow": 0.0,
+        "cost": -1.0
+      },
+      {
+          "name": "Storage 0",
+          "type": "Storage",
+          "max_volume": 20,
+          "initial_volume": 10
+      },
+      {
+          "name": "Output 0",
+          "type": "Output",
+          "max_flow": 8,
+          "cost": -999
+      },
+      {
+        "name": "Input 1",
+        "type": "input",
+        "max_flow": 5.0,
+        "cost": -1.0
+      },
+      {
+          "name": "Storage 1",
+          "type": "Storage",
+          "max_volume": 20,
+          "initial_volume": 11
+      },
+      {
+          "name": "Output 1",
+          "type": "Output",
+          "max_flow": 9,
+          "cost": -999
+      },
+      {
+        "name": "Input 2",
+        "type": "input",
+        "max_flow": 10.0,
+        "cost": -1.0
+      },
+      {
+          "name": "Storage 2",
+          "type": "Storage",
+          "max_volume": 20,
+          "initial_volume": 12
+      },
+      {
+          "name": "Output 2",
+          "type": "Output",
+          "max_flow": 10,
+          "cost": -999
+      },
+      {
+        "name": "Total Storage",
+        "type": "AggregatedStorage",
+        "storage_nodes": [
+          "Storage 0",
+          "Storage 1",
+          "Storage 2"
+        ]
+      },
+      {
+        "name": "Total Output",
+        "type": "AggregatedNode",
+        "nodes": [
+          "Output 0",
+          "Output 1",
+          "Output 2"
+        ]
+      }
+    ],
+    "edges": [
+        ["Input 0", "Storage 0"],
+        ["Storage 0", "Output 0"],
+        ["Input 1", "Storage 1"],
+        ["Storage 1", "Output 1"],
+        ["Input 2", "Storage 2"],
+        ["Storage 2", "Output 2"]
+    ]
+}

--- a/pywr_schema/tests/models/timeseries1.json
+++ b/pywr_schema/tests/models/timeseries1.json
@@ -1,0 +1,51 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "Input",
+            "max_flow": {
+                "type": "dataframe",
+                "url" : "timeseries1.csv",
+                "parse_dates": true,
+                "dayfirst": true,
+                "index_col": 0
+            }
+        },
+        {
+            "name": "river1",
+            "type": "Link"
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": -5
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "demand1"],
+        ["river1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/timeseries1_weekly.json
+++ b/pywr_schema/tests/models/timeseries1_weekly.json
@@ -1,0 +1,50 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-29",
+        "timestep": "W-THU"
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "Input",
+            "max_flow": {
+                "type": "dataframe",
+                "url" : "timeseries1_weekly.csv",
+                "parse_dates": true,
+                "index_col": 0
+            }
+        },
+        {
+            "name": "river1",
+            "type": "Link"
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": -5
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "demand1"],
+        ["river1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/timeseries1_weekly_hdf.json
+++ b/pywr_schema/tests/models/timeseries1_weekly_hdf.json
@@ -1,0 +1,48 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-31",
+        "timestep": 7
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "Input",
+            "max_flow": {
+                "type": "dataframe",
+                "url" : "timeseries1_weekly.h5"
+            }
+        },
+        {
+            "name": "river1",
+            "type": "Link"
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": -5
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "demand1"],
+        ["river1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/timeseries1_xlsx.json
+++ b/pywr_schema/tests/models/timeseries1_xlsx.json
@@ -1,0 +1,50 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "Input",
+            "max_flow": {
+                "type": "dataframe",
+                "url" : "test_data1.xlsx",
+                "sheet_name": "timeseries",
+                "index_col": 0
+            }
+        },
+        {
+            "name": "river1",
+            "type": "Link"
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": -5
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "demand1"],
+        ["river1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/timeseries2.json
+++ b/pywr_schema/tests/models/timeseries2.json
@@ -1,0 +1,61 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10
+        }
+    ],
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "Input",
+            "max_flow": {
+                "type": "dataframe",
+                "url" : "timeseries2.csv",
+                "checksum": {
+                    "md5": "a5c4032e2d8f5205ca99dedcfa4cd18e",
+                    "sha256": "0f75b3cee325d37112687d3d10596f44e0add374f4e40a1b6687912c05e65366"
+                },
+                "scenario": "scenario A",
+                "parse_dates": true,
+                "index_col": 0
+            }
+        },
+        {
+            "name": "river1",
+            "type": "Link"
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": -5
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "demand1"],
+        ["river1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/timeseries2_hdf.json
+++ b/pywr_schema/tests/models/timeseries2_hdf.json
@@ -1,0 +1,60 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10
+        }
+    ],
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": {
+                "type": "tablesarray",
+                "scenario": "scenario A",
+                "checksum": {
+                    "md5": "0f6c65a36851c89c7c4e63ab1893554b"
+                },
+                "url" : "timeseries2.h5",
+                "where": "/timeseries2",
+                "node": "block0_values"
+            }
+        },
+        {
+            "name": "river1",
+            "type": "Link"
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": -5
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "demand1"],
+        ["river1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/timeseries2_hdf_wrong_hash.json
+++ b/pywr_schema/tests/models/timeseries2_hdf_wrong_hash.json
@@ -1,0 +1,60 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10
+        }
+    ],
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": {
+                "type": "tablesarray",
+                "scenario": "scenario A",
+                "checksum": {
+                    "md5": "this hash is incorrect!"
+                },
+                "url" : "timeseries2.h5",
+                "where": "/timeseries2",
+                "node": "block0_values"
+            }
+        },
+        {
+            "name": "river1",
+            "type": "Link"
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": -5
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "demand1"],
+        ["river1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/timeseries2_with_fdc.json
+++ b/pywr_schema/tests/models/timeseries2_with_fdc.json
@@ -1,0 +1,86 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10
+        }
+    ],
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "Input",
+            "max_flow": {
+                "type": "dataframe",
+                "url" : "timeseries2.csv",
+                "checksum": {
+                    "md5": "a5c4032e2d8f5205ca99dedcfa4cd18e",
+                    "sha256": "0f75b3cee325d37112687d3d10596f44e0add374f4e40a1b6687912c05e65366"
+                },
+                "scenario": "scenario A",
+                "parse_dates": true,
+                "index_col": 0
+            }
+        },
+        {
+            "name": "river1",
+            "type": "Link"
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": -5
+        }
+    ],
+    "edges": [
+        ["catchment1", "river1"],
+        ["river1", "abs1"],
+        ["abs1", "demand1"],
+        ["river1", "term1"]
+    ],
+    "recorders": {
+        "fdc_dev1": {
+            "type": "flowdurationcurvedeviation",
+            "node": "term1",
+            "percentiles": [20, 40, 60, 80, 100],
+            "lower_target_fdc": {
+                "url": "fdc_targets.csv",
+                "index_col": 0
+            },
+            "upper_target_fdc": [
+                [22.462, 22.539, 24.882, 24.244, 22.616, 22.341, 22.011, 23.43 , 27.181, 26.686],
+                [23.958, 24.046, 26.532, 25.85 , 24.123, 23.826, 23.474, 24.992, 28.985, 28.457],
+                [25.542, 25.641, 28.292, 27.566, 25.729, 25.41 , 25.036, 26.653, 30.91 , 30.349],
+                [29.117, 29.227, 32.252, 31.427, 29.326, 28.963, 28.534, 30.382, 35.233, 34.595],
+                [32.241, 32.362, 35.717, 34.793, 32.472, 32.065, 31.603, 33.638, 39.017, 38.302]
+            ]
+        },
+        "fdc_dev2": {
+            "type": "flowdurationcurvedeviation",
+            "node": "term1",
+            "percentiles": [20, 40, 60, 80, 100],
+            "lower_target_fdc": [17.3376, 18.4904, 19.7184, 22.4768, 24.888],
+            "upper_target_fdc": [23.8392, 25.4243, 27.1128, 30.9056, 34.221]
+        }
+    }
+}

--- a/pywr_schema/tests/models/timeseries3.json
+++ b/pywr_schema/tests/models/timeseries3.json
@@ -1,0 +1,59 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10
+        }
+    ],
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": {
+                "type": "dataframe",
+                "url" : "timeseries2.csv",
+                "scenario": "scenario A",
+                "parse_dates": true,
+                "index_col": 0
+            }
+        },
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "initial_volume": 50.0,
+            "max_volume": 9999
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": 5
+        }
+    ],
+    "edges": [
+        ["catchment1", "reservoir1"],
+        ["reservoir1", "abs1"],
+        ["abs1", "demand1"],
+        ["reservoir1", "term1"]
+    ]
+}

--- a/pywr_schema/tests/models/timeseries3_subsample.json
+++ b/pywr_schema/tests/models/timeseries3_subsample.json
@@ -1,0 +1,63 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10
+        }
+    ],
+    "scenario_combinations": [[0], [9], [1], [0]],
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": "inflow"
+        },
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "initial_volume": 50.0,
+            "max_volume": 9999
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": 5
+        }
+    ],
+    "edges": [
+        ["catchment1", "reservoir1"],
+        ["reservoir1", "abs1"],
+        ["abs1", "demand1"],
+        ["reservoir1", "term1"]
+    ],
+    "parameters": {
+        "inflow": {
+            "type": "dataframe",
+            "url" : "timeseries2.csv",
+            "scenario": "scenario A",
+            "parse_dates": true,
+            "index_col": 0
+        }
+    }
+}

--- a/pywr_schema/tests/models/timeseries4.json
+++ b/pywr_schema/tests/models/timeseries4.json
@@ -1,0 +1,61 @@
+{
+    "metadata": {
+        "title": "Timeseries example",
+        "description": "A model with a timeseries",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2014-01-01",
+        "end": "2014-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": {
+                "type": "dataframe",
+                "url" : "timeseries3.csv",
+                "parse_dates": true,
+                "dayfirst": true,
+                "index_col": 0
+            }
+        },
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "initial_volume": 50.0,
+            "max_volume": 9999
+        },
+        {
+            "name": "abs1",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 23.0,
+            "cost": -10
+        },
+        {
+            "name": "term1",
+            "type": "Output",
+            "cost": 5
+        }
+    ],
+    "edges": [
+        ["catchment1", "reservoir1"],
+        ["reservoir1", "abs1"],
+        ["abs1", "demand1"],
+        ["reservoir1", "term1"]
+    ],
+    "recorders" : {
+      "seasonal_fdc": {
+              "type": "seasonalflowdurationcurverecorder",
+              "node": "catchment1",
+              "months": [6, 7, 8],
+              "percentiles": [20.0, 40.0, 60.0, 80.0, 100.0]
+      }
+    }
+}

--- a/pywr_schema/tests/models/two_reservoir.json
+++ b/pywr_schema/tests/models/two_reservoir.json
@@ -1,0 +1,139 @@
+{
+    "metadata": {
+        "title": "Two reservoirs",
+        "description": "A simple problem with two reservoirs.",
+        "minimum_version": "0.5"
+    },
+    "timestepper": {
+        "start": "2100-01-01",
+        "end": "2110-01-01",
+        "timestep": 7
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": "inflow"
+        },
+        {
+            "name": "catchment2",
+            "type": "catchment",
+            "flow": "inflow"
+        },
+        {
+            "name": "reservoir1",
+            "type": "storage",
+            "min_volume": 3000,
+            "max_volume": 20000,
+            "initial_volume": 16000,
+            "cost": -5
+        },
+        {
+            "name": "reservoir2",
+            "type": "storage",
+            "min_volume": 3000,
+            "max_volume": 20000,
+            "initial_volume": 16000,
+            "cost": -5
+        },
+        {
+            "name": "transfer",
+            "type": "link",
+            "cost": -500,
+            "max_flow": "transfer_controller"
+        },
+        {
+            "name": "demand1",
+            "type": "output",
+            "max_flow": 45.0,
+            "cost": -101
+        },
+        {
+            "name": "demand2",
+            "type": "output",
+            "max_flow": 20.0,
+            "cost": -100
+        },
+        {
+            "name": "river1",
+            "type": "link"
+        },
+        {
+            "name": "river2",
+            "type": "link"
+        },
+        {
+            "name": "compensation1",
+            "type": "rivergauge",
+            "mrf": 5.0,
+            "mrf_cost": -1000
+        },
+        {
+            "name": "compensation2",
+            "type": "rivergauge",
+            "mrf": 5.0,
+            "mrf_cost": -1000
+        },
+        {
+            "name": "terminator",
+            "type": "output"
+        }
+
+    ],
+    "edges": [
+        ["catchment1", "reservoir1"],
+        ["catchment2", "reservoir2"],
+        ["reservoir1", "river1"],
+        ["reservoir2", "river2"],
+        ["river1", "compensation1"],
+        ["river2", "compensation2"],
+        ["compensation1", "terminator"],
+        ["compensation2", "terminator"],
+        ["reservoir2", "transfer"],
+        ["transfer", "reservoir1"],
+        ["reservoir1", "demand1"],
+        ["reservoir2", "demand2"]
+    ],
+    "parameters": {
+        "inflow": {
+            "type": "dataframe",
+            "url": "data/thames_stochastic_flow.gz",
+            "index_col": "Date",
+            "column": "flow",
+            "parse_dates": true
+        },
+        "control_curve": {
+            "type": "monthlyprofile",
+            "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "is_variable": true,
+            "upper_bounds": 1.0
+        },
+        "transfer_controller": {
+            "type": "controlcurve",
+            "storage_node": "reservoir1",
+            "control_curve": "control_curve",
+            "values": [0.0, 10.0]
+        }
+    },
+    "recorders": {
+        "deficit1": {
+            "type": "totaldeficitnode",
+            "node": "demand1"
+        },
+        "deficit2": {
+            "type": "totaldeficitnode",
+            "node": "demand2"
+        },
+        "deficit": {
+            "type": "aggregated",
+            "recorders": ["deficit1", "deficit2"],
+            "recorder_agg_func": "sum",
+            "is_objective": "minimise"
+        },
+        "transferred": {
+            "type": "totalflownode",
+            "node": "transfer",
+            "is_objective": "minimise"
+        }
+    }
+}

--- a/pywr_schema/tests/models/two_reservoir_constrained.json
+++ b/pywr_schema/tests/models/two_reservoir_constrained.json
@@ -1,0 +1,145 @@
+{
+    "metadata": {
+        "title": "Two reservoirs",
+        "description": "A simple problem with two reservoirs.",
+        "minimum_version": "0.5"
+    },
+    "timestepper": {
+        "start": "2100-01-01",
+        "end": "2110-01-01",
+        "timestep": 7
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": "inflow"
+        },
+        {
+            "name": "catchment2",
+            "type": "catchment",
+            "flow": "inflow"
+        },
+        {
+            "name": "reservoir1",
+            "type": "storage",
+            "min_volume": 3000,
+            "max_volume": 20000,
+            "initial_volume": 16000,
+            "cost": -5
+        },
+        {
+            "name": "reservoir2",
+            "type": "storage",
+            "min_volume": 3000,
+            "max_volume": 20000,
+            "initial_volume": 16000,
+            "cost": -5
+        },
+        {
+            "name": "transfer",
+            "type": "link",
+            "cost": -500,
+            "max_flow": "transfer_controller"
+        },
+        {
+            "name": "demand1",
+            "type": "output",
+            "max_flow": 45.0,
+            "cost": -101
+        },
+        {
+            "name": "demand2",
+            "type": "output",
+            "max_flow": 20.0,
+            "cost": -100
+        },
+        {
+            "name": "river1",
+            "type": "link"
+        },
+        {
+            "name": "river2",
+            "type": "link"
+        },
+        {
+            "name": "compensation1",
+            "type": "rivergauge",
+            "mrf": 5.0,
+            "mrf_cost": -1000
+        },
+        {
+            "name": "compensation2",
+            "type": "rivergauge",
+            "mrf": 5.0,
+            "mrf_cost": -1000
+        },
+        {
+            "name": "terminator",
+            "type": "output"
+        }
+
+    ],
+    "edges": [
+        ["catchment1", "reservoir1"],
+        ["catchment2", "reservoir2"],
+        ["reservoir1", "river1"],
+        ["reservoir2", "river2"],
+        ["river1", "compensation1"],
+        ["river2", "compensation2"],
+        ["compensation1", "terminator"],
+        ["compensation2", "terminator"],
+        ["reservoir2", "transfer"],
+        ["transfer", "reservoir1"],
+        ["reservoir1", "demand1"],
+        ["reservoir2", "demand2"]
+    ],
+    "parameters": {
+        "inflow": {
+            "type": "dataframe",
+            "url": "data/thames_stochastic_flow.gz",
+            "index_col": "Date",
+            "column": "flow",
+            "parse_dates": true
+        },
+        "control_curve": {
+            "type": "monthlyprofile",
+            "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            "is_variable": true,
+            "upper_bounds": 1.0
+        },
+        "transfer_controller": {
+            "type": "controlcurve",
+            "storage_node": "reservoir1",
+            "control_curve": "control_curve",
+            "values": [0.0, 10.0]
+        }
+    },
+    "recorders": {
+        "deficit1": {
+            "type": "totaldeficitnode",
+            "node": "demand1"
+        },
+        "deficit2": {
+            "type": "totaldeficitnode",
+            "node": "demand2"
+        },
+        "deficit": {
+            "type": "aggregated",
+            "recorders": ["deficit1", "deficit2"],
+            "recorder_agg_func": "sum",
+            "is_objective": "minimise"
+        },
+        "transferred": {
+            "type": "totalflownode",
+            "node": "transfer",
+            "is_objective": "minimise"
+        },
+        "mean_transfer": {
+            "type": "meanflownode",
+            "node": "transfer",
+            "constraint_lower_bounds": 1.0,
+            "constraint_upper_bounds": 8.0
+        }
+    }
+}

--- a/pywr_schema/tests/models/version1.json
+++ b/pywr_schema/tests/models/version1.json
@@ -1,0 +1,28 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "99999"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"]
+    ]
+}

--- a/pywr_schema/tests/models/virtual_storage1.json
+++ b/pywr_schema/tests/models/virtual_storage1.json
@@ -1,0 +1,54 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage",
+        "description": "Annual abstraction licence implemented as an annual virtual storage",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100,
+            "cost": 0
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "licence1",
+            "type": "AnnualVirtualStorage",
+            "max_volume": 205,
+            "initial_volume": 205,
+            "nodes": [
+                "supply1"
+            ],
+            "factors": [
+                1.0
+            ],
+            "reset_day": 1,
+            "reset_month": 1
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/virtual_storage2.json
+++ b/pywr_schema/tests/models/virtual_storage2.json
@@ -1,0 +1,75 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage",
+        "description": "Annual abstraction licence implemented as an annual virtual storage with a dynamic cost.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-04-01",
+        "end": "2016-04-01",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 10,
+            "cost": "supply1_cost"
+        },
+        {
+            "name": "supply2",
+            "type": "Input",
+            "max_flow": 5,
+            "cost": 5
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -100
+        },
+        {
+            "name": "licence1",
+            "type": "AnnualVirtualStorage",
+            "max_volume": 3000,
+            "initial_volume": 3000,
+            "nodes": [
+                "supply1"
+            ],
+            "factors": [
+                1.0
+            ],
+            "reset_day": 1,
+            "reset_month": 4
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["supply2", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "supply1_cost": {
+            "type": "controlcurve",
+            "storage_node": "licence1",
+            "control_curves": [
+                {
+                    "type": "uniformdrawdownprofile",
+                    "reset_day": 1,
+                    "reset_month": 4
+                }
+            ],
+            "values":[0, 10]
+        }
+    },
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/virtual_storage3.json
+++ b/pywr_schema/tests/models/virtual_storage3.json
@@ -1,0 +1,57 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage with piecewise link",
+        "description": "Annual abstraction licence implemented as an annual virtual storage applied to a piecewise link.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100,
+            "cost": 0
+        },
+        {
+            "name": "link1",
+            "type": "PiecewiseLink",
+            "nsteps": 2,
+            "max_flows": [10, null],
+            "costs": [-1, 0]
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "licence1",
+            "type": "AnnualVirtualStorage",
+            "max_volume": 205,
+            "initial_volume": 205,
+            "nodes": [
+                "link1"
+            ],
+            "factors": [
+                1.0
+            ],
+            "reset_day": 1,
+            "reset_month": 1
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/virtual_storage4.json
+++ b/pywr_schema/tests/models/virtual_storage4.json
@@ -1,0 +1,59 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage with piecewise link",
+        "description": "Annual abstraction licence implemented as an annual virtual storage applied to an aggregated node.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100,
+            "cost": 0
+        },
+        {
+            "name": "link1",
+            "type": "link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "total1",
+            "type": "aggregatednode",
+            "nodes": ["link1"]
+        },
+        {
+            "name": "licence1",
+            "type": "AnnualVirtualStorage",
+            "max_volume": 205,
+            "initial_volume": 205,
+            "nodes": [
+                "total1"
+            ],
+            "factors": [
+                1.0
+            ],
+            "reset_day": 1,
+            "reset_month": 1
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/virtual_storage5.json
+++ b/pywr_schema/tests/models/virtual_storage5.json
@@ -1,0 +1,73 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage",
+        "description": "Annual abstraction licence implemented as an annual virtual storage with a dynamic cost and a residual license target.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 1,
+            "cost": "supply1_cost"
+        },
+        {
+            "name": "supply2",
+            "type": "Input",
+            "max_flow": 5,
+            "cost": 5
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 1,
+            "cost": -100
+        },
+        {
+            "name": "licence1",
+            "type": "AnnualVirtualStorage",
+            "max_volume": 365,
+            "initial_volume": 365,
+            "nodes": [
+                "supply1"
+            ],
+            "factors": [
+                1.0
+            ]
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["supply2", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "supply1_cost": {
+            "type": "controlcurve",
+            "storage_node": "licence1",
+            "control_curves": [
+                "drawdown"
+            ],
+            "values":[0, 10]
+        },
+        "drawdown": {
+            "type": "uniformdrawdownprofile",
+            "residual_days": 10
+        }
+    },
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/virtual_storage6.json
+++ b/pywr_schema/tests/models/virtual_storage6.json
@@ -1,0 +1,54 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage",
+        "description": "Annual abstraction licence implemented as an annual virtual storage",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100,
+            "cost": 0
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "licence1",
+            "type": "AnnualVirtualStorage",
+            "max_volume": 205,
+            "initial_volume_pc": 1.0,
+            "nodes": [
+                "supply1"
+            ],
+            "factors": [
+                1.0
+            ],
+            "reset_day": 1,
+            "reset_month": 1
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/virtual_storage7.json
+++ b/pywr_schema/tests/models/virtual_storage7.json
@@ -1,0 +1,61 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage",
+        "description": "Annual abstraction licence implemented as an annual virtual storage",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100,
+            "cost": 0
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "licence1",
+            "type": "AnnualVirtualStorage",
+            "max_volume": "licence_volume",
+            "initial_volume": 205,
+            "initial_volume_pc": 1.0,
+            "nodes": [
+                "supply1"
+            ],
+            "factors": [
+                1.0
+            ],
+            "reset_day": 1,
+            "reset_month": 1
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "licence_volume": {
+            "type": "constant",
+            "value": 205
+        }
+    },
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/virtual_storage8.json
+++ b/pywr_schema/tests/models/virtual_storage8.json
@@ -1,0 +1,53 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage",
+        "description": "Annual abstraction licence implemented as an annual virtual storage",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100,
+            "cost": 0
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "licence1",
+            "type": "MonthlyVirtualStorage",
+            "max_volume": 300,
+            "initial_volume": 300,
+            "nodes": [
+                "supply1"
+            ],
+            "factors": [
+                1.0
+            ],
+            "months": 3
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/pywr_schema/tests/models/virtual_storage9.json
+++ b/pywr_schema/tests/models/virtual_storage9.json
@@ -1,0 +1,61 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage",
+        "description": "Annual abstraction licence implemented as an annual virtual storage with a LossLink",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100,
+            "cost": 0
+        },
+        {
+            "name": "link1",
+            "type": "LossLink"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "licence1",
+            "type": "AnnualVirtualStorage",
+            "max_volume": "licence_volume",
+            "initial_volume": 205,
+            "initial_volume_pc": 1.0,
+            "nodes": [
+                "link1 Gross"
+            ],
+            "factors": [
+                1.0
+            ],
+            "reset_day": 1,
+            "reset_month": 1
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "licence_volume": {
+            "type": "constant",
+            "value": 205
+        }
+    },
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}


### PR DESCRIPTION
There's quite a bit here:

- Added a copy of the test model JSON files from the Pywr repository. The tests now check all of those models can be deserialised (but not serialised).
- Added derive macros `PywrNode` and `PywrParameter` that generate several methods for parameter and resource path discovery.
  - The `node_references` method could also be derived as well at some point.
- Implemented a method, `update_resource_paths`, that allows replacing paths in a model. 