### PR TITLE
feat: Separate out the network from the model.

### DIFF
--- a/pywr_schema/src/lib.rs
+++ b/pywr_schema/src/lib.rs
@@ -4,7 +4,7 @@ pub mod nodes;
 pub mod parameters;
 pub mod tables;
 
-pub use model::PywrModel;
+pub use model::{PywrModel, PywrNetwork};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This allows parsing partial Pywr JSON files which are often written as sub-models before assembling. The validator includes a switch to validate a JSON file as network only.