### PR TITLE
feat: Add most remaining threshold parameters to schema

### DIFF
--- a/pywr-v1-schema/src/parameters/mod.rs
+++ b/pywr-v1-schema/src/parameters/mod.rs
@@ -44,7 +44,11 @@ pub use crate::parameters::rolling_mean_flow_node::RollingMeanFlowNodeParameter;
 pub use crate::parameters::scenario_wrapper::ScenarioWrapperParameter;
 pub use crate::parameters::storage::StorageParameter;
 pub use crate::parameters::tables::TablesArrayParameter;
-pub use crate::parameters::thresholds::{ParameterThresholdParameter, Predicate};
+pub use crate::parameters::thresholds::{
+    CurrentOrdinalDayThresholdParameter, CurrentYearThresholdParameter,
+    MultipleThresholdIndexParameter, MultipleThresholdParameterIndexParameter,
+    NodeThresholdParameter, ParameterThresholdParameter, Predicate, StorageThresholdParameter,
+};
 pub use data_frame::DataFrameParameter;
 use serde::de::value::MapDeserializer;
 use serde::de::{MapAccess, Visitor};
@@ -202,6 +206,42 @@ pub enum CoreParameter {
     )]
     ParameterThreshold(ParameterThresholdParameter),
     #[serde(
+        alias = "nodethreshold",
+        alias = "nodethresholdparameter",
+        alias = "NodeThresholdParameter"
+    )]
+    NodeThreshold(NodeThresholdParameter),
+    #[serde(
+        alias = "storagethreshold",
+        alias = "storagethresholdparameter",
+        alias = "StorageThresholdParameter"
+    )]
+    StorageThreshold(StorageThresholdParameter),
+    #[serde(
+        alias = "multiplethresholdindex",
+        alias = "multiplethresholdindexparameter",
+        alias = "MultipleThresholdIndexParameter"
+    )]
+    MultipleThresholdIndex(MultipleThresholdIndexParameter),
+    #[serde(
+        alias = "multiplethresholdparameterindex",
+        alias = "multiplethresholdparameterindexparameter",
+        alias = "MultipleThresholdparameterIndexParameter"
+    )]
+    MultipleThresholdParameterIndex(MultipleThresholdParameterIndexParameter),
+    #[serde(
+        alias = "currentyearthreshold",
+        alias = "currentyearthresholdparameter",
+        alias = "CurrentYearThresholdParameter"
+    )]
+    CurrentYearThreshold(CurrentYearThresholdParameter),
+    #[serde(
+        alias = "currentordinaldaythreshold",
+        alias = "currentordinaldaythresholdparameter",
+        alias = "CurrentOrdinalDayThresholdParameter"
+    )]
+    CurrentOrdinalDayThreshold(CurrentOrdinalDayThresholdParameter),
+    #[serde(
         alias = "tablesarray",
         alias = "tablesarrayparameter",
         alias = "TablesArrayParameter"
@@ -297,6 +337,14 @@ impl CoreParameter {
             Self::Negative(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
             Self::Polynomial1D(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
             Self::ParameterThreshold(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
+            Self::NodeThreshold(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
+            Self::StorageThreshold(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
+            Self::MultipleThresholdIndex(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
+            Self::MultipleThresholdParameterIndex(p) => {
+                p.meta.as_ref().and_then(|m| m.name.as_deref())
+            }
+            Self::CurrentYearThreshold(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
+            Self::CurrentOrdinalDayThreshold(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
             Self::TablesArray(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
             Self::DataFrame(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
             Self::Deficit(p) => p.meta.as_ref().and_then(|m| m.name.as_deref()),
@@ -335,6 +383,12 @@ impl CoreParameter {
             Self::Negative(p) => p.node_references(),
             Self::Polynomial1D(p) => p.node_references(),
             Self::ParameterThreshold(p) => p.node_references(),
+            Self::NodeThreshold(p) => p.node_references(),
+            Self::StorageThreshold(p) => p.node_references(),
+            Self::MultipleThresholdIndex(p) => p.node_references(),
+            Self::MultipleThresholdParameterIndex(p) => p.node_references(),
+            Self::CurrentYearThreshold(p) => p.node_references(),
+            Self::CurrentOrdinalDayThreshold(p) => p.node_references(),
             Self::TablesArray(p) => p.node_references(),
             Self::DataFrame(p) => p.node_references(),
             Self::Deficit(p) => p.node_references(),
@@ -373,6 +427,12 @@ impl CoreParameter {
             Self::Negative(p) => p.parameters(),
             Self::Polynomial1D(p) => p.parameters(),
             Self::ParameterThreshold(p) => p.parameters(),
+            Self::NodeThreshold(p) => p.parameters(),
+            Self::StorageThreshold(p) => p.parameters(),
+            Self::MultipleThresholdIndex(p) => p.parameters(),
+            Self::MultipleThresholdParameterIndex(p) => p.parameters(),
+            Self::CurrentYearThreshold(p) => p.parameters(),
+            Self::CurrentOrdinalDayThreshold(p) => p.parameters(),
             Self::TablesArray(p) => p.parameters(),
             Self::DataFrame(p) => p.parameters(),
             Self::Deficit(p) => p.parameters(),
@@ -411,6 +471,12 @@ impl CoreParameter {
             Self::Negative(p) => p.parameters_mut(),
             Self::Polynomial1D(p) => p.parameters_mut(),
             Self::ParameterThreshold(p) => p.parameters_mut(),
+            Self::NodeThreshold(p) => p.parameters_mut(),
+            Self::StorageThreshold(p) => p.parameters_mut(),
+            Self::MultipleThresholdIndex(p) => p.parameters_mut(),
+            Self::MultipleThresholdParameterIndex(p) => p.parameters_mut(),
+            Self::CurrentYearThreshold(p) => p.parameters_mut(),
+            Self::CurrentOrdinalDayThreshold(p) => p.parameters_mut(),
             Self::TablesArray(p) => p.parameters_mut(),
             Self::DataFrame(p) => p.parameters_mut(),
             Self::Deficit(p) => p.parameters_mut(),
@@ -449,6 +515,12 @@ impl CoreParameter {
             Self::Negative(_) => "Negative",
             Self::Polynomial1D(_) => "Polynomial1D",
             Self::ParameterThreshold(_) => "ParameterThreshold",
+            Self::NodeThreshold(_) => "NodeThreshold",
+            Self::StorageThreshold(_) => "StorageThreshold",
+            Self::MultipleThresholdIndex(_) => "MultipleThresholdIndex",
+            Self::MultipleThresholdParameterIndex(_) => "MultipleThresholdIndex",
+            Self::CurrentYearThreshold(_) => "CurrentYearThreshold",
+            Self::CurrentOrdinalDayThreshold(_) => "CurrentOrdinalDayThreshold",
             Self::TablesArray(_) => "TablesArray",
             Self::DataFrame(_) => "DataFrame",
             Self::Deficit(_) => "Deficit",
@@ -488,6 +560,12 @@ impl CoreParameter {
             CoreParameter::NegativeMax(p) => p.resource_paths(),
             CoreParameter::Polynomial1D(p) => p.resource_paths(),
             CoreParameter::ParameterThreshold(p) => p.resource_paths(),
+            CoreParameter::NodeThreshold(p) => p.resource_paths(),
+            CoreParameter::StorageThreshold(p) => p.resource_paths(),
+            CoreParameter::MultipleThresholdIndex(p) => p.resource_paths(),
+            CoreParameter::MultipleThresholdParameterIndex(p) => p.resource_paths(),
+            CoreParameter::CurrentYearThreshold(p) => p.resource_paths(),
+            CoreParameter::CurrentOrdinalDayThreshold(p) => p.resource_paths(),
             CoreParameter::TablesArray(p) => p.resource_paths(),
             CoreParameter::DataFrame(p) => p.resource_paths(),
             CoreParameter::Deficit(p) => p.resource_paths(),
@@ -551,6 +629,12 @@ impl CoreParameter {
             CoreParameter::NegativeMax(p) => p.update_resource_paths(new_paths),
             CoreParameter::Polynomial1D(p) => p.update_resource_paths(new_paths),
             CoreParameter::ParameterThreshold(p) => p.update_resource_paths(new_paths),
+            CoreParameter::NodeThreshold(p) => p.update_resource_paths(new_paths),
+            CoreParameter::StorageThreshold(p) => p.update_resource_paths(new_paths),
+            CoreParameter::MultipleThresholdIndex(p) => p.update_resource_paths(new_paths),
+            CoreParameter::MultipleThresholdParameterIndex(p) => p.update_resource_paths(new_paths),
+            CoreParameter::CurrentYearThreshold(p) => p.update_resource_paths(new_paths),
+            CoreParameter::CurrentOrdinalDayThreshold(p) => p.update_resource_paths(new_paths),
             CoreParameter::TablesArray(p) => p.update_resource_paths(new_paths),
             CoreParameter::DataFrame(p) => p.update_resource_paths(new_paths),
             CoreParameter::Deficit(p) => p.update_resource_paths(new_paths),

--- a/pywr-v1-schema/src/parameters/thresholds.rs
+++ b/pywr-v1-schema/src/parameters/thresholds.rs
@@ -3,7 +3,7 @@ use pywr_v1_schema_macros::PywrParameter;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy)]
+#[derive(serde::Deserialize, serde::Serialize, PartialEq, Debug, Clone, Copy)]
 pub enum Predicate {
     #[serde(alias = "<")]
     LT,
@@ -17,6 +17,10 @@ pub enum Predicate {
     GE,
 }
 
+fn default_predicate() -> Predicate {
+    Predicate::LT
+}
+
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
 pub struct ParameterThresholdParameter {
     #[serde(flatten)]
@@ -24,11 +28,355 @@ pub struct ParameterThresholdParameter {
     pub parameter: ParameterValue,
     pub threshold: ParameterValue,
     pub values: Option<Vec<f64>>,
+    #[serde(default = "default_predicate")]
     pub predicate: Predicate,
 }
 
 impl ParameterThresholdParameter {
     pub fn node_references(&self) -> HashMap<&str, &str> {
         HashMap::new()
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
+pub struct NodeThresholdParameter {
+    #[serde(flatten)]
+    pub meta: Option<ParameterMeta>,
+    pub node: String,
+    pub threshold: ParameterValue,
+    pub values: Option<Vec<f64>>,
+    #[serde(default = "default_predicate")]
+    pub predicate: Predicate,
+}
+
+impl NodeThresholdParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        HashMap::new()
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
+pub struct StorageThresholdParameter {
+    #[serde(flatten)]
+    pub meta: Option<ParameterMeta>,
+    pub storage_node: String,
+    pub threshold: ParameterValue,
+    pub values: Option<Vec<f64>>,
+    #[serde(default = "default_predicate")]
+    pub predicate: Predicate,
+}
+
+impl StorageThresholdParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        HashMap::new()
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
+pub struct MultipleThresholdIndexParameter {
+    #[serde(flatten)]
+    pub meta: Option<ParameterMeta>,
+    pub node: String,
+    pub thresholds: Vec<ParameterValue>,
+    #[serde(default = "default_predicate")]
+    pub predicate: Predicate,
+}
+
+impl MultipleThresholdIndexParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        HashMap::new()
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
+pub struct MultipleThresholdParameterIndexParameter {
+    #[serde(flatten)]
+    pub meta: Option<ParameterMeta>,
+    pub parameter: ParameterValue,
+    pub thresholds: Vec<ParameterValue>,
+    #[serde(default = "default_predicate")]
+    pub predicate: Predicate,
+}
+
+impl MultipleThresholdParameterIndexParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        HashMap::new()
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
+pub struct CurrentYearThresholdParameter {
+    #[serde(flatten)]
+    pub meta: Option<ParameterMeta>,
+    pub threshold: ParameterValue,
+    pub values: Option<Vec<f64>>,
+    #[serde(default = "default_predicate")]
+    pub predicate: Predicate,
+}
+
+impl CurrentYearThresholdParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        HashMap::new()
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PywrParameter)]
+pub struct CurrentOrdinalDayThresholdParameter {
+    #[serde(flatten)]
+    pub meta: Option<ParameterMeta>,
+    pub threshold: ParameterValue,
+    pub values: Option<Vec<f64>>,
+    #[serde(default = "default_predicate")]
+    pub predicate: Predicate,
+}
+
+impl CurrentOrdinalDayThresholdParameter {
+    pub fn node_references(&self) -> HashMap<&str, &str> {
+        HashMap::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parameters::{
+        thresholds::{
+            CurrentOrdinalDayThresholdParameter, CurrentYearThresholdParameter,
+            MultipleThresholdIndexParameter, MultipleThresholdParameterIndexParameter,
+            NodeThresholdParameter, StorageThresholdParameter,
+        },
+        ParameterThresholdParameter, ParameterValue, Predicate,
+    };
+
+    #[test]
+    fn test_param() {
+        let data = r#"
+            {
+                "type": "parameterthreshold",
+                "parameter": "Param1",
+                "threshold": 5.0,
+                "predicate": ">=",
+                "values": [
+                    2.0,
+                    0
+                ]
+            }
+            "#;
+        let param: ParameterThresholdParameter = serde_json::from_str(data).unwrap();
+
+        match param.predicate {
+            Predicate::GE => {}
+            _ => panic!("Predicate is not correct"),
+        }
+
+        match param.parameter {
+            ParameterValue::Reference(val) => {
+                assert_eq!(val, "Param1");
+            }
+            _ => panic!("Parameter is not a reference"),
+        }
+
+        match param.threshold {
+            ParameterValue::Constant(val) => {
+                assert_eq!(val, 5.0);
+            }
+            _ => panic!("Threshold is not a constant"),
+        }
+
+        assert_eq!(param.values, Some(vec![2.0, 0.0]));
+    }
+
+    #[test]
+    fn test_node() {
+        let data = r#"
+            {
+                "type": "nodethreshold",
+                "node": "Gauge1",
+                "threshold": 5.0,
+                "values": [
+                    2.0,
+                    0
+                ]
+            }
+            "#;
+        let param: NodeThresholdParameter = serde_json::from_str(data).unwrap();
+
+        match param.predicate {
+            Predicate::LT => {}
+            _ => panic!("Predicate is not correct"),
+        }
+
+        assert_eq!(param.node, "Gauge1");
+
+        match param.threshold {
+            ParameterValue::Constant(val) => {
+                assert_eq!(val, 5.0);
+            }
+            _ => panic!("Threshold is not a constant"),
+        }
+
+        assert_eq!(param.values, Some(vec![2.0, 0.0]));
+    }
+
+    #[test]
+    fn test_storage() {
+        let data = r#"
+            {
+                "type": "storagethreshold",
+                "storage_node": "Res1",
+                "threshold": 1000.0,
+                "predicate": ">",
+                "values": [
+                    10.0,
+                    0
+                ]
+            }
+            "#;
+        let param: StorageThresholdParameter = serde_json::from_str(data).unwrap();
+
+        match param.predicate {
+            Predicate::GT => {}
+            _ => panic!("Predicate is not correct"),
+        }
+
+        assert_eq!(param.storage_node, "Res1");
+
+        match param.threshold {
+            ParameterValue::Constant(val) => {
+                assert_eq!(val, 1000.0);
+            }
+            _ => panic!("Threshold is not a constant"),
+        }
+
+        assert_eq!(param.values, Some(vec![10.0, 0.0]));
+    }
+
+    #[test]
+    fn test_multi_thresholds() {
+        let data = r#"
+            {
+                "type": "multiplethresholdindex",
+                "node": "Gauge1",
+                "thresholds": [2.0, 7.0],
+                "predicate": ">"
+            }
+            "#;
+        let param: MultipleThresholdIndexParameter = serde_json::from_str(data).unwrap();
+
+        match param.predicate {
+            Predicate::GT => {}
+            _ => panic!("Predicate is not correct"),
+        }
+
+        assert_eq!(param.node, "Gauge1");
+
+        match param.thresholds[0] {
+            ParameterValue::Constant(val) => {
+                assert_eq!(val, 2.0);
+            }
+            _ => panic!("Threshold is not a constant"),
+        }
+
+        match param.thresholds[1] {
+            ParameterValue::Constant(val) => {
+                assert_eq!(val, 7.0);
+            }
+            _ => panic!("Threshold is not a constant"),
+        }
+    }
+
+    #[test]
+    fn test_multi_thresholds_param() {
+        let data = r#"
+            {
+                "type": "multiplethresholdparameterindex",
+                "parameter": "Param1",
+                "thresholds": [2.0, 7.0],
+                "predicate": ">"
+            }
+            "#;
+        let param: MultipleThresholdParameterIndexParameter = serde_json::from_str(data).unwrap();
+
+        match param.predicate {
+            Predicate::GT => {}
+            _ => panic!("Predicate is not correct"),
+        }
+
+        match param.parameter {
+            ParameterValue::Reference(val) => {
+                assert_eq!(val, "Param1");
+            }
+            _ => panic!("Parameter is not a reference"),
+        }
+        match param.thresholds[0] {
+            ParameterValue::Constant(val) => {
+                assert_eq!(val, 2.0);
+            }
+            _ => panic!("Threshold is not a constant"),
+        }
+
+        match param.thresholds[1] {
+            ParameterValue::Constant(val) => {
+                assert_eq!(val, 7.0);
+            }
+            _ => panic!("Threshold is not a constant"),
+        }
+    }
+
+    #[test]
+    fn test_current_year() {
+        let data = r#"
+            {
+                "type": "currentyearthreshold",
+                "threshold": 5.0,
+                "values": [
+                    2.0,
+                    0
+                ]
+            }
+            "#;
+        let param: CurrentYearThresholdParameter = serde_json::from_str(data).unwrap();
+
+        match param.predicate {
+            Predicate::LT => {}
+            _ => panic!("Predicate is not correct"),
+        }
+
+        match param.threshold {
+            ParameterValue::Constant(val) => {
+                assert_eq!(val, 5.0);
+            }
+            _ => panic!("Threshold is not a constant"),
+        }
+
+        assert_eq!(param.values, Some(vec![2.0, 0.0]));
+    }
+
+    #[test]
+    fn test_current_ordinal_day() {
+        let data = r#"
+            {
+                "type": "currentordinaldaythreshold",
+                "threshold": 5.0,
+                "values": [
+                    2.0,
+                    0
+                ]
+            }
+            "#;
+        let param: CurrentOrdinalDayThresholdParameter = serde_json::from_str(data).unwrap();
+
+        match param.predicate {
+            Predicate::LT => {}
+            _ => panic!("Predicate is not correct"),
+        }
+
+        match param.threshold {
+            ParameterValue::Constant(val) => {
+                assert_eq!(val, 5.0);
+            }
+            _ => panic!("Threshold is not a constant"),
+        }
+
+        assert_eq!(param.values, Some(vec![2.0, 0.0]));
     }
 }


### PR DESCRIPTION
The `RecorderThresholdParameter` is omitted because recorder schemas have not been implemented yet.