### PR TITLE
fix: Add is_variable field to ParameterMeta.

### DIFF
--- a/pywr-v1-schema/src/parameters/mod.rs
+++ b/pywr-v1-schema/src/parameters/mod.rs
@@ -68,6 +68,8 @@ pub struct ParameterMeta {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_variable: Option<bool>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
@@ -836,6 +838,7 @@ impl<'de> Visitor<'de> for PywrParameterMapVisitor {
                         meta: ParameterMeta {
                             name: Some(name),
                             comment: value.comment,
+                            is_variable: None,
                         },
                         ty: value.ty,
                         attributes: value.attributes,


### PR DESCRIPTION
This allows correctly deserialising parameters with this field. It is a attribute in the base `Parameter` class in Pywr. Therefore, all parameter could have this set, but it only makes sense in some cases.