### PR TITLE
ci: Protect breaking commits from being skipped.

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -51,7 +51,7 @@ commit_parsers = [
     { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
-protect_breaking_commits = false
+protect_breaking_commits = true
 
 # sort the commits inside sections by oldest/newest order
 sort_commits = "oldest"


### PR DESCRIPTION
Set `protect_breaking_commits = true` in release-plz.toml.